### PR TITLE
Using resolver as data oracle solution

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,22 +39,15 @@ linters-settings:
 linters:
   enable:
     - bodyclose
-    - megacheck
     - revive
     - govet
     - unconvert
-    - megacheck
-    - structcheck
-    - gas
     - gocyclo
     - dupl
     - misspell
     - unparam
-    - varcheck
-    - deadcode
     - typecheck
     - ineffassign
-    - varcheck
     - stylecheck
     - gochecknoinits
     - exportloopref

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ##
 ## Build did driver
 ##
-FROM golang:1.18-alpine as base
+FROM golang:1.18-alpine AS base
 
 WORKDIR /build
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Driver for the polygonid DID method.
         amoy:
             contractAddress: "0x1a4cC30f2aA0377b0c3bc9848766D90cb4404124"
             networkURL: "https://polygon-amoy..."
+            walletKey: "<private ethereum key for signing EIP712>"
     ```
+    `walletKey` is only needed for the resolver if it's a trusted resolver that includes signature of EIP712 message when requested in the resolution with `signature=EthereumEip712Signature2021`.
 2. Build docker container:
     ```bash
     docker build -t driver-did-polygonid:local .
@@ -26,6 +28,7 @@ Driver for the polygonid DID method.
         amoy:
             contractAddress: "0x1a4cC30f2aA0377b0c3bc9848766D90cb4404124"
             networkURL: "<POLYGON_AMOY_RPC_URL>"
+            walletKey: "<private ethereum key for signing EIP712>"
     ```
 2. Build docker container:
     ```bash

--- a/cmd/driver/main.go
+++ b/cmd/driver/main.go
@@ -63,7 +63,7 @@ func initResolvers() *services.ResolverRegistry {
 	for chainName, chainSettings := range rs {
 		for networkName, networkSettings := range chainSettings {
 			prefix := fmt.Sprintf("%s:%s", chainName, networkName)
-			resolver, err := eth.NewResolver(networkSettings.NetworkURL, networkSettings.ContractAddress)
+			resolver, err := eth.NewResolver(networkSettings.NetworkURL, networkSettings.ContractAddress, networkSettings.WalletKey)
 			if err != nil {
 				log.Fatalf("failed configure resolver for network '%s': %v", prefix, err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/iden3/contracts-abi/state/go/abi v0.0.0-20230405152923-4a25f6f1f0f4
 	github.com/iden3/go-iden3-core/v2 v2.2.0
-	github.com/iden3/go-schema-processor/v2 v2.4.3-0.20240716072750-b7d560a31765
+	github.com/iden3/go-schema-processor/v2 v2.4.2
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/iden3/contracts-abi/state/go/abi v0.0.0-20230405152923-4a25f6f1f0f4
 	github.com/iden3/go-iden3-core/v2 v2.2.0
-	github.com/iden3/go-schema-processor/v2 v2.4.2
+	github.com/iden3/go-schema-processor/v2 v2.4.3-0.20240716072750-b7d560a31765
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
@@ -18,6 +18,8 @@ require (
 )
 
 require (
+	github.com/FactomProject/basen v0.0.0-20150613233007-fe3947df716e // indirect
+	github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec // indirect
 	github.com/dchest/blake512 v1.0.0 // indirect
 	github.com/deckarep/golang-set/v2 v2.2.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
@@ -55,6 +57,8 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect
+	github.com/tyler-smith/go-bip32 v1.0.0
+	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/wealdtech/go-multicodec v1.4.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	golang.org/x/sys v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,8 @@
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
+github.com/FactomProject/basen v0.0.0-20150613233007-fe3947df716e h1:ahyvB3q25YnZWly5Gq1ekg6jcmWaGj/vG/MhF4aisoc=
+github.com/FactomProject/basen v0.0.0-20150613233007-fe3947df716e/go.mod h1:kGUqhHd//musdITWjFvNTHn90WG9bMLBEPQZ17Cmlpw=
+github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec h1:1Qb69mGp/UtRPn422BH4/Y4Q3SLUrD9KHuDkm8iodFc=
+github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec/go.mod h1:CD8UlnlLDiqb36L110uqiP2iSflVjx9g/3U9hCI4q2U=
 github.com/VictoriaMetrics/fastcache v1.6.0 h1:C/3Oi3EiBCqufydp1neRZkqcwmEiuRT9c3fqvvgKm5o=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -20,6 +24,7 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/cespare/cp v1.1.1 h1:nCb6ZLdB7NRaqsm91JtQTAme2SKJzXVsdPIPkyJr1MU=
 github.com/cespare/cp v1.1.1/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cmars/basen v0.0.0-20150613233007-fe3947df716e/go.mod h1:P13beTBKr5Q18lJe1rIoLUqjM+CB1zYrRg44ZqGuQSA=
 github.com/cockroachdb/errors v1.9.1 h1:yFVvsI0VxmRShfawbt/laCIDy/mtTqqnvoNgiy5bEV8=
 github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b h1:r6VH0faHjZeQy818SGhaone5OnYfxFR/+AzdY3sf5aE=
 github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811 h1:ytcWPaNPhNoGMWEhDvS3zToKcDpRsLuRolQJBVGdozk=
@@ -79,6 +84,8 @@ github.com/iden3/go-merkletree-sql/v2 v2.0.4 h1:Dp089P3YNX1BE8+T1tKQHWTtnk84Y/Kr
 github.com/iden3/go-merkletree-sql/v2 v2.0.4/go.mod h1:kRhHKYpui5DUsry5RpveP6IC4XMe6iApdV9VChRYuEk=
 github.com/iden3/go-schema-processor/v2 v2.4.2 h1:t9pMxSpyMDAU3xSpn2dTvnTUUAtPlwOcNavbgXEFiJk=
 github.com/iden3/go-schema-processor/v2 v2.4.2/go.mod h1:eBtILnPjh4wnsAg3LWnvcZlGG+5IkAJaRqhVBnDjerg=
+github.com/iden3/go-schema-processor/v2 v2.4.3-0.20240716072750-b7d560a31765 h1:UDdW0gP8GoOFVcIGrsAgDGAcLzI2IXSFMDQ2KYxd38k=
+github.com/iden3/go-schema-processor/v2 v2.4.3-0.20240716072750-b7d560a31765/go.mod h1:eBtILnPjh4wnsAg3LWnvcZlGG+5IkAJaRqhVBnDjerg=
 github.com/ipfs/go-cid v0.3.2 h1:OGgOd+JCFM+y1DjWPmVH+2/4POtpDzwcr7VgnB7mZXc=
 github.com/ipfs/go-cid v0.3.2/go.mod h1:gQ8pKqT/sUxGY+tIwy1RPpAojYu7jAyCp5Tz1svoupw=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
@@ -147,6 +154,7 @@ github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0b
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.1.5-0.20170601210322-f6abca593680/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
@@ -155,7 +163,10 @@ github.com/tklauser/go-sysconf v0.3.11 h1:89WgdJhk5SNwJfu+GKyYveZ4IaJ7xAkecBo+Kd
 github.com/tklauser/go-sysconf v0.3.11/go.mod h1:GqXfhXY3kiPa0nAXPDIQIWzJbMCB7AmcWpGR8lSZfqI=
 github.com/tklauser/numcpus v0.6.0 h1:kebhY2Qt+3U6RNK7UqpYNA+tJ23IBEGKkB7JQBfDYms=
 github.com/tklauser/numcpus v0.6.0/go.mod h1:FEZLMke0lhOUG6w2JadTzp0a+Nl8PF/GFkQ5UVIcaL4=
+github.com/tyler-smith/go-bip32 v1.0.0 h1:sDR9juArbUgX+bO/iblgZnMPeWY1KZMUC2AFUJdv5KE=
+github.com/tyler-smith/go-bip32 v1.0.0/go.mod h1:onot+eHknzV4BVPwrzqY5OoVpyCvnwD7lMawL5aQupE=
 github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
+github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/urfave/cli/v2 v2.17.2-0.20221006022127-8f469abc00aa h1:5SqCsI/2Qya2bCzK15ozrqo2sZxkh0FHynJZOTVoV6Q=
 github.com/wealdtech/go-ens/v3 v3.5.5 h1:/jq3CDItK0AsFnZtiFJK44JthkAMD5YE3WAJOh4i7lc=
 github.com/wealdtech/go-ens/v3 v3.5.5/go.mod h1:w0EDKIm0dIQnqEKls6ORat/or+AVfPEdEXVfN71EeEE=
@@ -166,11 +177,13 @@ github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRT
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPRg=
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+golang.org/x/crypto v0.0.0-20170613210332-850760c427c5/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.12.0 h1:tFM/ta59kqch6LlvYnPa0yx5a83cL2nHflFhYKvv9Yk=
 golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
 golang.org/x/exp v0.0.0-20230206171751-46f607a40771 h1:xP7rWLUr1e1n2xkK5YB4LI0hPEy3LJC6Wk+D4pGlOJg=
@@ -220,5 +233,6 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+launchpad.net/gocheck v0.0.0-20140225173054-000000000087/go.mod h1:hj7XX3B/0A+80Vse0e+BUHsHMTEhd0O4cpUHr/e/BUM=
 lukechampine.com/blake3 v1.1.7 h1:GgRMhmdsuK8+ii6UZFDL8Nb+VyMwadAgcJyfYHxG6n0=
 lukechampine.com/blake3 v1.1.7/go.mod h1:tkKEOtDkNtklkXtLNEOGNq5tcV90tJiA1vAA12R78LA=

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,6 @@ github.com/iden3/go-merkletree-sql/v2 v2.0.4 h1:Dp089P3YNX1BE8+T1tKQHWTtnk84Y/Kr
 github.com/iden3/go-merkletree-sql/v2 v2.0.4/go.mod h1:kRhHKYpui5DUsry5RpveP6IC4XMe6iApdV9VChRYuEk=
 github.com/iden3/go-schema-processor/v2 v2.4.2 h1:t9pMxSpyMDAU3xSpn2dTvnTUUAtPlwOcNavbgXEFiJk=
 github.com/iden3/go-schema-processor/v2 v2.4.2/go.mod h1:eBtILnPjh4wnsAg3LWnvcZlGG+5IkAJaRqhVBnDjerg=
-github.com/iden3/go-schema-processor/v2 v2.4.3-0.20240716072750-b7d560a31765 h1:UDdW0gP8GoOFVcIGrsAgDGAcLzI2IXSFMDQ2KYxd38k=
-github.com/iden3/go-schema-processor/v2 v2.4.3-0.20240716072750-b7d560a31765/go.mod h1:eBtILnPjh4wnsAg3LWnvcZlGG+5IkAJaRqhVBnDjerg=
 github.com/ipfs/go-cid v0.3.2 h1:OGgOd+JCFM+y1DjWPmVH+2/4POtpDzwcr7VgnB7mZXc=
 github.com/ipfs/go-cid v0.3.2/go.mod h1:gQ8pKqT/sUxGY+tIwy1RPpAojYu7jAyCp5Tz1svoupw=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=

--- a/pkg/app/configs/driver.go
+++ b/pkg/app/configs/driver.go
@@ -16,6 +16,7 @@ const defaultPathToResolverSettings = "./resolvers.settings.yaml"
 type ResolverSettings map[string]map[string]struct {
 	ContractAddress string `yaml:"contractAddress"`
 	NetworkURL      string `yaml:"networkURL"`
+	WalletKey       string `yaml:"walletKey"`
 }
 
 // Config structure represent yaml config for did driver.

--- a/pkg/app/handler.go
+++ b/pkg/app/handler.go
@@ -97,7 +97,7 @@ func (d *DidDocumentHandler) GetGist(w http.ResponseWriter, r *http.Request) {
 	gistInfo, err := d.DidDocumentService.GetGist(r.Context(), chain, networkid, nil)
 	if errors.Is(err, services.ErrNetworkIsNotSupported) {
 		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprintf(w, `{"error":"resolver for '%s:%s' network not found"}`, chain, networkid)
+		log.Printf(`{"error":"resolver for '%s:%s' network not found"}`, chain, networkid)
 		return
 	} else if err != nil {
 		log.Printf("failed get info about latest gist from network '%s:%s': %v\n", chain, networkid, err)

--- a/pkg/document/did.go
+++ b/pkg/document/did.go
@@ -80,10 +80,11 @@ func NewDidErrorResolution(errCode ErrorCode, errMsg string) *DidResolution {
 
 // DidResolutionMetadata representation of resolution metadata.
 type DidResolutionMetadata struct {
-	Error       ErrorCode `json:"error,omitempty"`
-	Message     string    `json:"message,omitempty"`
-	ContentType string    `json:"contentType,omitempty"`
-	Retrieved   time.Time `json:"retrieved,omitempty"`
+	Error       ErrorCode           `json:"error,omitempty"`
+	Message     string              `json:"message,omitempty"`
+	ContentType string              `json:"contentType,omitempty"`
+	Retrieved   time.Time           `json:"retrieved,omitempty"`
+	Proof       DidResolutionProofs `json:"proof,omitempty"`
 }
 
 // DidDocumentMetadata metadata of did document.

--- a/pkg/document/did.go
+++ b/pkg/document/did.go
@@ -47,6 +47,8 @@ func NewDidResolution() *DidResolution {
 			VerificationMethod: []verifiable.CommonVerificationMethod{},
 		},
 		DidResolutionMetadata: &DidResolutionMetadata{
+			Context:     []string{iden3ResolutionContext},
+			Type:        Iden3ResolutionMetadataType,
 			ContentType: defaultContentType,
 			Retrieved:   time.Now(),
 		},

--- a/pkg/document/did.go
+++ b/pkg/document/did.go
@@ -15,14 +15,17 @@ const (
 	ErrUnknownNetwork     ErrorCode = "unknownNetwork"
 
 	StateType                            = "Iden3StateInfo2023"
+	Iden3ResolutionMetadataType          = "Iden3ResolutionMetadata"
 	EcdsaSecp256k1RecoveryMethod2020Type = "EcdsaSecp256k1RecoveryMethod2020"
 )
 
 const (
-	defaultContext       = "https://w3id.org/did-resolution/v1"
-	defaultDidDocContext = "https://www.w3.org/ns/did/v1"
-	iden3Context         = "https://schema.iden3.io/core/jsonld/auth.jsonld"
-	defaultContentType   = "application/did+ld+json"
+	defaultContext         = "https://w3id.org/did-resolution/v1"
+	defaultDidDocContext   = "https://www.w3.org/ns/did/v1"
+	iden3Context           = "https://schema.iden3.io/core/jsonld/auth.jsonld"
+	defaultContentType     = "application/did+ld+json"
+	iden3ResolutionContext = "https://schema.iden3.io/core/jsonld/resolution.jsonld"
+	eip712sigContext       = "https://w3id.org/security/suites/eip712sig-2021/v1"
 )
 
 // DidResolution representation of did resolution.
@@ -49,6 +52,10 @@ func NewDidResolution() *DidResolution {
 		},
 		DidDocumentMetadata: &DidDocumentMetadata{},
 	}
+}
+
+func DidResolutionMetadataSigContext() []string {
+	return []string{iden3ResolutionContext, eip712sigContext}
 }
 
 func NewDidMethodNotSupportedResolution(msg string) *DidResolution {
@@ -80,6 +87,7 @@ func NewDidErrorResolution(errCode ErrorCode, errMsg string) *DidResolution {
 
 // DidResolutionMetadata representation of resolution metadata.
 type DidResolutionMetadata struct {
+	Context     interface{}         `json:"@context,omitempty"`
 	Error       ErrorCode           `json:"error,omitempty"`
 	Message     string              `json:"message,omitempty"`
 	ContentType string              `json:"contentType,omitempty"`

--- a/pkg/document/did.go
+++ b/pkg/document/did.go
@@ -84,6 +84,7 @@ type DidResolutionMetadata struct {
 	Message     string              `json:"message,omitempty"`
 	ContentType string              `json:"contentType,omitempty"`
 	Retrieved   time.Time           `json:"retrieved,omitempty"`
+	Type        string              `json:"type,omitempty"`
 	Proof       DidResolutionProofs `json:"proof,omitempty"`
 }
 

--- a/pkg/document/proof.go
+++ b/pkg/document/proof.go
@@ -1,0 +1,61 @@
+package document
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
+	"github.com/iden3/go-schema-processor/v2/verifiable"
+)
+
+type DidResolutionProof interface {
+	ProofType() verifiable.ProofType
+}
+
+type DidResolutionProofs []DidResolutionProof
+
+type EthereumEip712SignatureProof2021 struct {
+	Type               verifiable.ProofType `json:"type"`
+	ProofPursopose     string               `json:"proofPurpose"`
+	ProofValue         string               `json:"proofValue"`
+	VerificationMethod string               `json:"verificationMethod"`
+	Created            time.Time            `json:"created"`
+	Eip712             apitypes.TypedData   `json:"eip712"`
+}
+
+// EthereumEip712Signature2021Type is a proof type for EIP172 signature proofs
+const EthereumEip712SignatureProof2021Type verifiable.ProofType = "EthereumEip712Signature2021"
+
+func (p *EthereumEip712SignatureProof2021) ProofType() verifiable.ProofType {
+	return p.Type
+}
+
+func (p *EthereumEip712SignatureProof2021) UnmarshalJSON(in []byte) error {
+	var obj struct {
+		Type               verifiable.ProofType `json:"type"`
+		ProofPursopose     string               `json:"proofPurpose"`
+		ProofValue         string               `json:"proofValue"`
+		VerificationMethod string               `json:"verificationMethod"`
+		Created            time.Time            `json:"created"`
+		Eip712             json.RawMessage      `json:"eip712"`
+	}
+	err := json.Unmarshal(in, &obj)
+	if err != nil {
+		return err
+	}
+	if obj.Type != EthereumEip712SignatureProof2021Type {
+		return errors.New("invalid proof type")
+	}
+	p.Type = obj.Type
+	err = json.Unmarshal(obj.Eip712, &p.Eip712)
+	if err != nil {
+		return err
+	}
+	p.VerificationMethod = obj.VerificationMethod
+	p.ProofPursopose = obj.ProofPursopose
+	// TODO: validate proof value
+	p.ProofValue = obj.ProofValue
+	p.Created = obj.Created
+	return nil
+}

--- a/pkg/document/proof.go
+++ b/pkg/document/proof.go
@@ -25,6 +25,7 @@ type EthereumEip712SignatureProof2021 struct {
 }
 
 // EthereumEip712Signature2021Type is a proof type for EIP172 signature proofs
+// nolint:stylecheck // we need to keep the name as it is
 const EthereumEip712SignatureProof2021Type verifiable.ProofType = "EthereumEip712Signature2021"
 
 func (p *EthereumEip712SignatureProof2021) ProofType() verifiable.ProofType {

--- a/pkg/document/proof_test.go
+++ b/pkg/document/proof_test.go
@@ -23,8 +23,7 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 					{ "name": "name", "type": "string" },
 					{ "name": "version", "type": "string" },
 					{ "name": "chainId", "type": "uint256" },
-					{ "name": "verifyingContract", "type": "address" },
-					{ "name": "salt", "type": "string" }
+					{ "name": "verifyingContract", "type": "address" }
 				],
 				"IdentityState": [
 					{ "name": "from", "type": "address" },
@@ -38,8 +37,7 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 				"name": "StateInfo",
 				"version": "1",
 				"chainId": "0x1",
-				"verifyingContract": "0x0000000000000000000000000000000000000000",
-				"salt": "resolver-privado.id"
+				"verifyingContract": "0x0000000000000000000000000000000000000000"
 			},
 			"message": {
 				"from": "0x5b18eF56aA61eeAE0E3434e3c3d8AEB19b141fe7",
@@ -67,12 +65,10 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 			{Name: "version", Type: "string"},
 			{Name: "chainId", Type: "uint256"},
 			{Name: "verifyingContract", Type: "address"},
-			{Name: "salt", Type: "string"},
 		},
 	}
 
 	var primaryType = "IdentityState"
-	salt := "resolver-privado.id"
 	walletAddress := "0x5b18eF56aA61eeAE0E3434e3c3d8AEB19b141fe7"
 	state := "444"
 	gistRoot := "555"
@@ -91,7 +87,6 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 			Domain: apitypes.TypedDataDomain{
 				Name:              "StateInfo",
 				Version:           "1",
-				Salt:              salt,
 				ChainId:           math.NewHexOrDecimal256(int64(chainID)),
 				VerifyingContract: "0x0000000000000000000000000000000000000000",
 			},

--- a/pkg/document/proof_test.go
+++ b/pkg/document/proof_test.go
@@ -21,10 +21,10 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 			"types": {
 				"EIP712Domain": [
 					{ "name": "name", "type": "string" },
-					{ "name": "chainId", "type": "uint256" },
 					{ "name": "version", "type": "string" },
-					{ "name": "salt", "type": "string" },
-					{ "name": "verifyingContract", "type": "address" }
+					{ "name": "chainId", "type": "uint256" },
+					{ "name": "verifyingContract", "type": "address" },
+					{ "name": "salt", "type": "string" }
 				],
 				"IdentityState": [
 					{ "name": "from", "type": "address" },
@@ -64,10 +64,10 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 		},
 		"EIP712Domain": []apitypes.Type{
 			{Name: "name", Type: "string"},
-			{Name: "chainId", Type: "uint256"},
 			{Name: "version", Type: "string"},
-			{Name: "salt", Type: "string"},
+			{Name: "chainId", Type: "uint256"},
 			{Name: "verifyingContract", Type: "address"},
+			{Name: "salt", Type: "string"},
 		},
 	}
 

--- a/pkg/document/proof_test.go
+++ b/pkg/document/proof_test.go
@@ -28,7 +28,11 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 				"IdentityState": [
 					{ "name": "from", "type": "address" },
 					{ "name": "state", "type": "uint256" },
+					{ "name": "stateCreatedAtTimestamp", "type": "uint256" },
+					{ "name": "stateReplacedAtTimestamp", "type": "uint256" },
 					{ "name": "gistRoot", "type": "uint256" },
+					{ "name": "gistRootCreatedAtTimestamp", "type": "uint256" },
+					{ "name": "gistRootReplacedAtTimestamp", "type": "uint256" },
 					{ "name": "identity", "type": "uint256" }
 				]
 			},
@@ -41,9 +45,13 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 			},
 			"message": {
 				"from": "0x5b18eF56aA61eeAE0E3434e3c3d8AEB19b141fe7",
-				"gistRoot": "555",
-				"identity": "19090607534999372304474213543962416547920895595808567155882840509226423042",
-				"state": "444"
+				"state": "444",
+				"stateCreatedAtTimestamp": "0",
+				"stateReplacedAtTimestamp": "0",
+				"gistRoot": "555",				
+				"gistRootCreatedAtTimestamp": "0",				
+				"gistRootReplacedAtTimestamp": "0",				
+				"identity": "19090607534999372304474213543962416547920895595808567155882840509226423042"
 			}
 		}
 	}`
@@ -57,7 +65,11 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 		"IdentityState": []apitypes.Type{
 			{Name: "from", Type: "address"},
 			{Name: "state", Type: "uint256"},
+			{Name: "stateCreatedAtTimestamp", Type: "uint256"},
+			{Name: "stateReplacedAtTimestamp", Type: "uint256"},
 			{Name: "gistRoot", Type: "uint256"},
+			{Name: "gistRootCreatedAtTimestamp", Type: "uint256"},
+			{Name: "gistRootReplacedAtTimestamp", Type: "uint256"},
 			{Name: "identity", Type: "uint256"},
 		},
 		"EIP712Domain": []apitypes.Type{
@@ -71,6 +83,10 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 	var primaryType = "IdentityState"
 	walletAddress := "0x5b18eF56aA61eeAE0E3434e3c3d8AEB19b141fe7"
 	state := "444"
+	stateCreatedAtTimestamp := "0"
+	stateReplacedAtTimestamp := "0"
+	gistRootCreatedAtTimestamp := "0"
+	gistRootReplacedAtTimestamp := "0"
 	gistRoot := "555"
 	identity := "19090607534999372304474213543962416547920895595808567155882840509226423042"
 	chainID := 1
@@ -91,10 +107,14 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 				VerifyingContract: "0x0000000000000000000000000000000000000000",
 			},
 			Message: apitypes.TypedDataMessage{
-				"from":     walletAddress,
-				"state":    state,
-				"gistRoot": gistRoot,
-				"identity": identity,
+				"from":                        walletAddress,
+				"state":                       state,
+				"stateCreatedAtTimestamp":     stateCreatedAtTimestamp,
+				"stateReplacedAtTimestamp":    stateReplacedAtTimestamp,
+				"gistRoot":                    gistRoot,
+				"gistRootCreatedAtTimestamp":  gistRootCreatedAtTimestamp,
+				"gistRootReplacedAtTimestamp": gistRootReplacedAtTimestamp,
+				"identity":                    identity,
 			},
 		},
 	}

--- a/pkg/document/proof_test.go
+++ b/pkg/document/proof_test.go
@@ -30,9 +30,11 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 					{ "name": "timestamp", "type": "uint256" },
 					{ "name": "state", "type": "uint256" },
 					{ "name": "stateCreatedAtTimestamp", "type": "uint256" },
+					{ "name": "stateReplacedByState", "type": "uint256" },
 					{ "name": "stateReplacedAtTimestamp", "type": "uint256" },
 					{ "name": "gistRoot", "type": "uint256" },
 					{ "name": "gistRootCreatedAtTimestamp", "type": "uint256" },
+					{ "name": "gistRootReplacedByRoot", "type": "uint256" },
 					{ "name": "gistRootReplacedAtTimestamp", "type": "uint256" },
 					{ "name": "identity", "type": "uint256" }
 				]
@@ -49,9 +51,11 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 				"timestamp": "0",
 				"state": "444",
 				"stateCreatedAtTimestamp": "0",
+				"stateReplacedByState": "0",
 				"stateReplacedAtTimestamp": "0",
 				"gistRoot": "555",				
 				"gistRootCreatedAtTimestamp": "0",				
+				"gistRootReplacedByRoot": "0",				
 				"gistRootReplacedAtTimestamp": "0",				
 				"identity": "19090607534999372304474213543962416547920895595808567155882840509226423042"
 			}
@@ -69,9 +73,11 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 			{Name: "timestamp", Type: "uint256"},
 			{Name: "state", Type: "uint256"},
 			{Name: "stateCreatedAtTimestamp", Type: "uint256"},
+			{Name: "stateReplacedByState", Type: "uint256"},
 			{Name: "stateReplacedAtTimestamp", Type: "uint256"},
 			{Name: "gistRoot", Type: "uint256"},
 			{Name: "gistRootCreatedAtTimestamp", Type: "uint256"},
+			{Name: "gistRootReplacedByRoot", Type: "uint256"},
 			{Name: "gistRootReplacedAtTimestamp", Type: "uint256"},
 			{Name: "identity", Type: "uint256"},
 		},
@@ -87,8 +93,10 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 	walletAddress := "0x5b18eF56aA61eeAE0E3434e3c3d8AEB19b141fe7"
 	state := "444"
 	stateCreatedAtTimestamp := "0"
+	stateReplacedByState := "0"
 	stateReplacedAtTimestamp := "0"
 	gistRootCreatedAtTimestamp := "0"
+	gistRootReplacedByRoot := "0"
 	gistRootReplacedAtTimestamp := "0"
 	timestamp := "0"
 	gistRoot := "555"
@@ -115,9 +123,11 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 				"timestamp":                   timestamp,
 				"state":                       state,
 				"stateCreatedAtTimestamp":     stateCreatedAtTimestamp,
+				"stateReplacedByState":        stateReplacedByState,
 				"stateReplacedAtTimestamp":    stateReplacedAtTimestamp,
 				"gistRoot":                    gistRoot,
 				"gistRootCreatedAtTimestamp":  gistRootCreatedAtTimestamp,
+				"gistRootReplacedByRoot":      gistRootReplacedByRoot,
 				"gistRootReplacedAtTimestamp": gistRootReplacedAtTimestamp,
 				"identity":                    identity,
 			},

--- a/pkg/document/proof_test.go
+++ b/pkg/document/proof_test.go
@@ -23,7 +23,8 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 					{ "name": "name", "type": "string" },
 					{ "name": "chainId", "type": "uint256" },
 					{ "name": "version", "type": "string" },
-					{ "name": "salt", "type": "string" }
+					{ "name": "salt", "type": "string" },
+					{ "name": "verifyingContract", "type": "address" }
 				],
 				"IdentityState": [
 					{ "name": "from", "type": "address" },
@@ -37,8 +38,8 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 				"name": "StateInfo",
 				"version": "1",
 				"chainId": "0x1",
-				"verifyingContract": "",
-				"salt": "resolver-123"
+				"verifyingContract": "0x0000000000000000000000000000000000000000",
+				"salt": "resolver-privado.id"
 			},
 			"message": {
 				"from": "0x5b18eF56aA61eeAE0E3434e3c3d8AEB19b141fe7",
@@ -66,11 +67,12 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 			{Name: "chainId", Type: "uint256"},
 			{Name: "version", Type: "string"},
 			{Name: "salt", Type: "string"},
+			{Name: "verifyingContract", Type: "address"},
 		},
 	}
 
 	var primaryType = "IdentityState"
-	salt := "resolver-123"
+	salt := "resolver-privado.id"
 	walletAddress := "0x5b18eF56aA61eeAE0E3434e3c3d8AEB19b141fe7"
 	state := "444"
 	gistRoot := "555"
@@ -87,10 +89,11 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 			Types:       apiTypes,
 			PrimaryType: primaryType,
 			Domain: apitypes.TypedDataDomain{
-				Name:    "StateInfo",
-				Version: "1",
-				Salt:    salt,
-				ChainId: math.NewHexOrDecimal256(int64(chainID)),
+				Name:              "StateInfo",
+				Version:           "1",
+				Salt:              salt,
+				ChainId:           math.NewHexOrDecimal256(int64(chainID)),
+				VerifyingContract: "0x0000000000000000000000000000000000000000",
 			},
 			Message: apitypes.TypedDataMessage{
 				"from":     walletAddress,

--- a/pkg/document/proof_test.go
+++ b/pkg/document/proof_test.go
@@ -1,0 +1,104 @@
+package document
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
+	in := `{
+  "type": "EthereumEip712Signature2021",
+	"proofPurpose": "assertionMethod",
+	"proofValue": "0xd5e5ffe290a258116a0f7acb4c9a5bbfdd842516061c6a794892b6db05fbd14706de7e189d965bead2ffb23e30d2f6b02ecf764e6fe24be788721049b7e331481c",
+	"verificationMethod": "did:pkh:eip155:1:0x5b18eF56aA61eeAE0E3434e3c3d8AEB19b141fe7#blockchainAccountId",
+	"created": "2021-09-23T20:21:34Z",
+	"eip712": {
+			"types": {
+				"EIP712Domain": [
+					{ "name": "name", "type": "string" },
+					{ "name": "chainId", "type": "uint256" },
+					{ "name": "version", "type": "string" },
+					{ "name": "salt", "type": "string" }
+				],
+				"IdentityState": [
+					{ "name": "from", "type": "address" },
+					{ "name": "state", "type": "uint256" },
+					{ "name": "gistRoot", "type": "uint256" },
+					{ "name": "identity", "type": "uint256" }
+				]
+			},
+			"primaryType": "IdentityState",
+			"domain": {
+				"name": "StateInfo",
+				"version": "1",
+				"chainId": "0x1",
+				"verifyingContract": "",
+				"salt": "resolver-123"
+			},
+			"message": {
+				"from": "0x5b18eF56aA61eeAE0E3434e3c3d8AEB19b141fe7",
+				"gistRoot": "555",
+				"identity": "19090607534999372304474213543962416547920895595808567155882840509226423042",
+				"state": "444"
+			}
+		}
+	}`
+	var proof EthereumEip712SignatureProof2021
+	err := json.Unmarshal([]byte(in), &proof)
+	require.NoError(t, err)
+
+	timeParsed, _ := time.Parse("2006-01-02T15:04:05Z", "2021-09-23T20:21:34Z")
+
+	var apiTypes = apitypes.Types{
+		"IdentityState": []apitypes.Type{
+			{Name: "from", Type: "address"},
+			{Name: "state", Type: "uint256"},
+			{Name: "gistRoot", Type: "uint256"},
+			{Name: "identity", Type: "uint256"},
+		},
+		"EIP712Domain": []apitypes.Type{
+			{Name: "name", Type: "string"},
+			{Name: "chainId", Type: "uint256"},
+			{Name: "version", Type: "string"},
+			{Name: "salt", Type: "string"},
+		},
+	}
+
+	var primaryType = "IdentityState"
+	salt := "resolver-123"
+	walletAddress := "0x5b18eF56aA61eeAE0E3434e3c3d8AEB19b141fe7"
+	state := "444"
+	gistRoot := "555"
+	identity := "19090607534999372304474213543962416547920895595808567155882840509226423042"
+	chainID := 1
+
+	wantProof := EthereumEip712SignatureProof2021{
+		Type:               "EthereumEip712Signature2021",
+		ProofPursopose:     "assertionMethod",
+		ProofValue:         "0xd5e5ffe290a258116a0f7acb4c9a5bbfdd842516061c6a794892b6db05fbd14706de7e189d965bead2ffb23e30d2f6b02ecf764e6fe24be788721049b7e331481c",
+		VerificationMethod: "did:pkh:eip155:1:0x5b18eF56aA61eeAE0E3434e3c3d8AEB19b141fe7#blockchainAccountId",
+		Created:            timeParsed,
+		Eip712: apitypes.TypedData{
+			Types:       apiTypes,
+			PrimaryType: primaryType,
+			Domain: apitypes.TypedDataDomain{
+				Name:    "StateInfo",
+				Version: "1",
+				Salt:    salt,
+				ChainId: math.NewHexOrDecimal256(int64(chainID)),
+			},
+			Message: apitypes.TypedDataMessage{
+				"from":     walletAddress,
+				"state":    state,
+				"gistRoot": gistRoot,
+				"identity": identity,
+			},
+		},
+	}
+	require.Equal(t, wantProof, proof)
+}

--- a/pkg/document/proof_test.go
+++ b/pkg/document/proof_test.go
@@ -27,6 +27,7 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 				],
 				"IdentityState": [
 					{ "name": "from", "type": "address" },
+					{ "name": "timestamp", "type": "uint256" },
 					{ "name": "state", "type": "uint256" },
 					{ "name": "stateCreatedAtTimestamp", "type": "uint256" },
 					{ "name": "stateReplacedAtTimestamp", "type": "uint256" },
@@ -45,6 +46,7 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 			},
 			"message": {
 				"from": "0x5b18eF56aA61eeAE0E3434e3c3d8AEB19b141fe7",
+				"timestamp": "0",
 				"state": "444",
 				"stateCreatedAtTimestamp": "0",
 				"stateReplacedAtTimestamp": "0",
@@ -64,6 +66,7 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 	var apiTypes = apitypes.Types{
 		"IdentityState": []apitypes.Type{
 			{Name: "from", Type: "address"},
+			{Name: "timestamp", Type: "uint256"},
 			{Name: "state", Type: "uint256"},
 			{Name: "stateCreatedAtTimestamp", Type: "uint256"},
 			{Name: "stateReplacedAtTimestamp", Type: "uint256"},
@@ -87,6 +90,7 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 	stateReplacedAtTimestamp := "0"
 	gistRootCreatedAtTimestamp := "0"
 	gistRootReplacedAtTimestamp := "0"
+	timestamp := "0"
 	gistRoot := "555"
 	identity := "19090607534999372304474213543962416547920895595808567155882840509226423042"
 	chainID := 1
@@ -108,6 +112,7 @@ func TestEthereumEip712SignatureProof2021_JSONUnmarshal(t *testing.T) {
 			},
 			Message: apitypes.TypedDataMessage{
 				"from":                        walletAddress,
+				"timestamp":                   timestamp,
 				"state":                       state,
 				"stateCreatedAtTimestamp":     stateCreatedAtTimestamp,
 				"stateReplacedAtTimestamp":    stateReplacedAtTimestamp,

--- a/pkg/services/blockchain/eth/resolver.go
+++ b/pkg/services/blockchain/eth/resolver.go
@@ -176,7 +176,8 @@ func (r *Resolver) Resolve(
 			return services.IdentityState{},
 				errors.New("options GistRoot is required for root only did")
 		}
-		stateInfo, gistInfo, err = r.resolveGistRootOnly(ctx, opts.GistRoot)
+		stateInfo = nil
+		gistInfo, err = r.resolveGistRootOnly(ctx, opts.GistRoot)
 	} else {
 		userID, err := core.IDFromDID(did)
 		if err != nil {
@@ -367,7 +368,7 @@ func (r *Resolver) verifyTypedData(authData AuthData) (bool, error) {
 		return false, fmt.Errorf("decode signature: %w", err)
 	}
 
-	// EIP-712 typed data marshalling
+	// EIP-712 typed data marshaling
 	domainSeparator, err := authData.TypedData.HashStruct("EIP712Domain", authData.TypedData.Domain.Map())
 	if err != nil {
 		return false, fmt.Errorf("eip712domain hash struct: %w", err)
@@ -482,13 +483,13 @@ func (r *Resolver) resolveStateByGistRoot(
 func (r *Resolver) resolveGistRootOnly(
 	ctx context.Context,
 	gistRoot *big.Int,
-) (*abi.IStateStateInfo, *abi.IStateGistRootInfo, error) {
+) (*abi.IStateGistRootInfo, error) {
 	gistInfo, err := r.state.GetGISTRootInfo(&bind.CallOpts{Context: ctx}, gistRoot)
 	if err = notFoundErr(err); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return nil, &gistInfo, nil
+	return &gistInfo, nil
 }
 
 func verifyContractState(id core.ID, state abi.IStateStateInfo) error {

--- a/pkg/services/blockchain/eth/resolver.go
+++ b/pkg/services/blockchain/eth/resolver.go
@@ -59,9 +59,11 @@ var apiTypes = apitypes.Types{
 		{Name: "timestamp", Type: "uint256"},
 		{Name: "state", Type: "uint256"},
 		{Name: "stateCreatedAtTimestamp", Type: "uint256"},
+		{Name: "stateReplacedByState", Type: "uint256"},
 		{Name: "stateReplacedAtTimestamp", Type: "uint256"},
 		{Name: "gistRoot", Type: "uint256"},
 		{Name: "gistRootCreatedAtTimestamp", Type: "uint256"},
+		{Name: "gistRootReplacedByRoot", Type: "uint256"},
 		{Name: "gistRootReplacedAtTimestamp", Type: "uint256"},
 		{Name: "identity", Type: "uint256"},
 	},
@@ -278,19 +280,23 @@ func (r *Resolver) TypedData(did w3c.DID, identityState services.IdentityState, 
 	}
 	stateInfoState := "0"
 	stateInfoCreatedAtTimestamp := "0"
+	stateInfoReplacedByState := "0"
 	stateInfoReplacedAtTimestamp := "0"
+	gistInfoRoot := "0"
+	gistInfoCreatedAtTimestamp := "0"
+	gistInfoReplacedByRoot := "0"
+	gistInfoReplacedAtTimestamp := "0"
 
 	if identityState.StateInfo != nil {
 		stateInfoState = identityState.StateInfo.State.String()
 		stateInfoCreatedAtTimestamp = identityState.StateInfo.CreatedAtTimestamp.String()
+		stateInfoReplacedByState = identityState.StateInfo.ReplacedByState.String()
 		stateInfoReplacedAtTimestamp = identityState.StateInfo.ReplacedAtTimestamp.String()
 	}
-	gistInfoRoot := "0"
-	gistInfoCreatedAtTimestamp := "0"
-	gistInfoReplacedAtTimestamp := "0"
 	if identityState.GistInfo != nil {
 		gistInfoRoot = identityState.GistInfo.Root.String()
 		gistInfoCreatedAtTimestamp = identityState.GistInfo.CreatedAtTimestamp.String()
+		gistInfoReplacedByRoot = identityState.GistInfo.ReplacedByRoot.String()
 		gistInfoReplacedAtTimestamp = identityState.GistInfo.ReplacedAtTimestamp.String()
 	}
 
@@ -309,9 +315,11 @@ func (r *Resolver) TypedData(did w3c.DID, identityState services.IdentityState, 
 			"timestamp":                   timestamp,
 			"state":                       stateInfoState,
 			"stateCreatedAtTimestamp":     stateInfoCreatedAtTimestamp,
+			"stateReplacedByState":        stateInfoReplacedByState,
 			"stateReplacedAtTimestamp":    stateInfoReplacedAtTimestamp,
 			"gistRoot":                    gistInfoRoot,
 			"gistRootCreatedAtTimestamp":  gistInfoCreatedAtTimestamp,
+			"gistRootReplacedByRoot":      gistInfoReplacedByRoot,
 			"gistRootReplacedAtTimestamp": gistInfoReplacedAtTimestamp,
 			"identity":                    identity,
 		},

--- a/pkg/services/blockchain/eth/resolver.go
+++ b/pkg/services/blockchain/eth/resolver.go
@@ -60,10 +60,10 @@ var apiTypes = apitypes.Types{
 	},
 	"EIP712Domain": []apitypes.Type{
 		{Name: "name", Type: "string"},
-		{Name: "chainId", Type: "uint256"},
 		{Name: "version", Type: "string"},
-		{Name: "salt", Type: "string"},
+		{Name: "chainId", Type: "uint256"},
 		{Name: "verifyingContract", Type: "address"},
+		{Name: "salt", Type: "string"},
 	},
 }
 

--- a/pkg/services/blockchain/eth/resolver.go
+++ b/pkg/services/blockchain/eth/resolver.go
@@ -63,6 +63,7 @@ var apiTypes = apitypes.Types{
 		{Name: "chainId", Type: "uint256"},
 		{Name: "version", Type: "string"},
 		{Name: "salt", Type: "string"},
+		{Name: "verifyingContract", Type: "address"},
 	},
 }
 
@@ -263,16 +264,17 @@ func (r *Resolver) TypedData(did w3c.DID, state string, gistRoot string, walletA
 	}
 	identity := userID.BigInt().String()
 
-	salt := "resolver-123"
+	salt := "resolver-privado.id"
 
 	typedData := apitypes.TypedData{
 		Types:       apiTypes,
 		PrimaryType: primaryType,
 		Domain: apitypes.TypedDataDomain{
-			Name:    "StateInfo",
-			Version: "1",
-			Salt:    salt,
-			ChainId: math.NewHexOrDecimal256(int64(r.chainID)),
+			Name:              "StateInfo",
+			Version:           "1",
+			Salt:              salt,
+			ChainId:           math.NewHexOrDecimal256(int64(r.chainID)),
+			VerifyingContract: "0x0000000000000000000000000000000000000000",
 		},
 		Message: apitypes.TypedDataMessage{
 			"from":     walletAddress,

--- a/pkg/services/blockchain/eth/resolver.go
+++ b/pkg/services/blockchain/eth/resolver.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strconv"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -54,6 +56,7 @@ var (
 var apiTypes = apitypes.Types{
 	"IdentityState": []apitypes.Type{
 		{Name: "from", Type: "address"},
+		{Name: "timestamp", Type: "uint256"},
 		{Name: "state", Type: "uint256"},
 		{Name: "stateCreatedAtTimestamp", Type: "uint256"},
 		{Name: "stateReplacedAtTimestamp", Type: "uint256"},
@@ -71,6 +74,8 @@ var apiTypes = apitypes.Types{
 }
 
 var primaryType = "IdentityState"
+
+var TimeStamp = TimeStampFn
 
 // NewResolver create new ethereum resolver.
 func NewResolver(url, address, walletKey string) (*Resolver, error) {
@@ -261,6 +266,11 @@ func (r *Resolver) VerifyIdentityState(
 	return r.verifyTypedData(authData)
 }
 
+func TimeStampFn() string {
+	timestamp := strconv.FormatInt(time.Now().UTC().Unix(), 10)
+	return timestamp
+}
+
 func (r *Resolver) TypedData(verifyingContract services.VerifyingContract, did w3c.DID, identityState services.IdentityState, walletAddress string) (apitypes.TypedData, error) {
 	identity := "0"
 	if did.IDStrings[2] != "000000000000000000000000000000000000000000" {
@@ -289,6 +299,7 @@ func (r *Resolver) TypedData(verifyingContract services.VerifyingContract, did w
 		gistInfoReplacedAtTimestamp = identityState.GistInfo.ReplacedAtTimestamp.String()
 	}
 
+	timestamp := TimeStamp()
 	typedData := apitypes.TypedData{
 		Types:       apiTypes,
 		PrimaryType: primaryType,
@@ -300,6 +311,7 @@ func (r *Resolver) TypedData(verifyingContract services.VerifyingContract, did w
 		},
 		Message: apitypes.TypedDataMessage{
 			"from":                        walletAddress,
+			"timestamp":                   timestamp,
 			"state":                       stateInfoState,
 			"stateCreatedAtTimestamp":     stateInfoCreatedAtTimestamp,
 			"stateReplacedAtTimestamp":    stateInfoReplacedAtTimestamp,

--- a/pkg/services/blockchain/eth/resolver.go
+++ b/pkg/services/blockchain/eth/resolver.go
@@ -217,13 +217,7 @@ func (r *Resolver) Resolve(
 	}
 
 	signature := ""
-	if r.walletKey != "" {
-		if opts.VerifyingContractChainId == nil {
-			return services.IdentityState{}, errors.New("error verifying contract chainId is not set")
-		}
-		if opts.VerifyingContractAddress == "" {
-			return services.IdentityState{}, errors.New("error verifying contract address is not set")
-		}
+	if r.walletKey != "" && opts.VerifyingContractChainId != nil && opts.VerifyingContractAddress != "" {
 		verifyingContract := services.VerifyingContract{
 			ChainId: *opts.VerifyingContractChainId,
 			Address: opts.VerifyingContractAddress,
@@ -236,9 +230,6 @@ func (r *Resolver) Resolve(
 	}
 
 	identityState.Signature = signature
-
-	// verified, _ := r.VerifyIdentityState(identityState, did)
-	// log.Println("VERIFIED:", verified)
 
 	return identityState, err
 }

--- a/pkg/services/blockchain/eth/resolver.go
+++ b/pkg/services/blockchain/eth/resolver.go
@@ -53,7 +53,7 @@ var (
 	stateNotFoundException    = "execution reverted: State does not exist"
 )
 
-var IdentityStateApiTypes = apitypes.Types{
+var IdentityStateAPITypes = apitypes.Types{
 	"IdentityState": []apitypes.Type{
 		{Name: "from", Type: "address"},
 		{Name: "timestamp", Type: "uint256"},
@@ -71,7 +71,7 @@ var IdentityStateApiTypes = apitypes.Types{
 	},
 }
 
-var GlobalStateApiTypes = apitypes.Types{
+var GlobalStateAPITypes = apitypes.Types{
 	"GlobalState": []apitypes.Type{
 		{Name: "from", Type: "address"},
 		{Name: "timestamp", Type: "uint256"},
@@ -237,9 +237,9 @@ func (r *Resolver) Resolve(
 
 	signature := ""
 	if r.walletKey != "" && opts.Signature != "" {
-		primaryType := services.IDENTITY_STATE_TYPE
+		primaryType := services.IdentityStateType
 		if stateInfo == nil {
-			primaryType = services.GLOBAL_STATE_TYPE
+			primaryType = services.GlobalStateType
 		}
 		signature, err = r.signTypedData(primaryType, did, identityState)
 		if err != nil {
@@ -321,9 +321,9 @@ func (r *Resolver) TypedData(primaryType services.PrimaryType, did w3c.DID, iden
 	timestamp := TimeStamp()
 
 	switch primaryType {
-	case services.IDENTITY_STATE_TYPE:
+	case services.IdentityStateType:
 		primaryTypeString = "IdentityState"
-		apiTypes = IdentityStateApiTypes
+		apiTypes = IdentityStateAPITypes
 		message = apitypes.TypedDataMessage{
 			"from":                walletAddress,
 			"timestamp":           timestamp,
@@ -333,9 +333,9 @@ func (r *Resolver) TypedData(primaryType services.PrimaryType, did w3c.DID, iden
 			"createdAtTimestamp":  createdAtTimestamp,
 			"replacedAtTimestamp": replacedAtTimestamp,
 		}
-	case services.GLOBAL_STATE_TYPE:
+	case services.GlobalStateType:
 		primaryTypeString = "GlobalState"
-		apiTypes = GlobalStateApiTypes
+		apiTypes = GlobalStateAPITypes
 		message = apitypes.TypedDataMessage{
 			"from":                walletAddress,
 			"timestamp":           timestamp,

--- a/pkg/services/blockchain/eth/resolver_test.go
+++ b/pkg/services/blockchain/eth/resolver_test.go
@@ -240,7 +240,7 @@ func TestResolveSignature_Success(t *testing.T) {
 				GistInfo: &services.GistInfo{
 					Root: big.NewInt(555),
 				},
-				Signature: "0xae5dec0aaebed043dc78e9a2beef4dd355eaae7ed63958c725b4917e1246dffe0eae7f85438c1c500c891c59dff8b5ee55c1a52c09fcd42418a154ba32b00d431c",
+				Signature: "0xd0488105cd2af066b7aa7cb36091cd6a9328b8c365df0914e7392a721918c76d42b644ae364258072a5436706bdbd65d603fd657814d17dcabba3c7bd31c7a411b",
 			},
 		},
 		{
@@ -260,7 +260,7 @@ func TestResolveSignature_Success(t *testing.T) {
 					State: big.NewInt(555),
 				},
 				GistInfo:  nil,
-				Signature: "0xb84222149169ccbca64716c9bf932779feebadfdd1a2e3ecc8376af69352e9be4380a7aebe7c1442a94e2fc139ed4f193820454b9b4ad926e0da267b5e1968301c",
+				Signature: "0x0ee7c23eb141aa0d7e4a47469de211ec6d3ae01cb0850786112db15d5d7673164c2c9a3e1f3dc880cea4bf280e3bbeb52f4750f4d32152c20dcdefadc25212411c",
 			},
 		},
 		{
@@ -284,7 +284,7 @@ func TestResolveSignature_Success(t *testing.T) {
 				GistInfo: &services.GistInfo{
 					Root: big.NewInt(400),
 				},
-				Signature: "0x92df22c50364bbb1b18a03df7b651b2e5287eb05fc631f313195dca3d0255d5155407b15cb60622ba48d94fb134342dbcb1a34318a11e316de8a37a16dc9b7821b",
+				Signature: "0xdb4a1e6e5cb5dce2c9815cb612edc19e7bcd655f5e1c72370753c4d2df9ea11a698a970f99915847e1e0146ef7f36adb97088d9f7143f7293af72c05fd3e4d991b",
 			},
 		},
 	}

--- a/pkg/services/blockchain/eth/resolver_test.go
+++ b/pkg/services/blockchain/eth/resolver_test.go
@@ -208,6 +208,8 @@ func TestNotFoundErr(t *testing.T) {
 func TestResolveSignature_Success(t *testing.T) {
 	verifyingContractChainId := new(int)
 	*verifyingContractChainId = 1
+	userEmptyDID, _ := w3c.ParseDID("did:polygonid:polygon:amoy:000000000000000000000000000000000000000000")
+
 	tests := []struct {
 		name                  string
 		opts                  *services.ResolverOpts
@@ -304,6 +306,29 @@ func TestResolveSignature_Success(t *testing.T) {
 					ReplacedAtTimestamp: big.NewInt(0),
 				},
 				Signature: "0xee0ba8b277b71b4b3e79c668d5e3de169e5e72f92b3bb4e8637e570ca6c810bd5684d01b9a9b7fbbead7528040715b77d9a8177aa3de72a589851cd252dd6a111b",
+			},
+		},
+		{
+			name: "resolve only gist",
+			opts: &services.ResolverOpts{
+				GistRoot:                 big.NewInt(400),
+				VerifyingContractChainId: verifyingContractChainId,
+				VerifyingContractAddress: "0x0000000000000000000000000000000000000000",
+			},
+			userDID: userEmptyDID,
+			contractMock: func(c *cm.MockStateContract) {
+				latestGist := big.NewInt(400)
+				latestGistInfo := abi.IStateGistRootInfo{Root: big.NewInt(400), CreatedAtTimestamp: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
+				c.EXPECT().GetGISTRootInfo(gomock.Any(), latestGist).Return(latestGistInfo, nil)
+			},
+			expectedIdentityState: services.IdentityState{
+				StateInfo: nil,
+				GistInfo: &services.GistInfo{
+					Root:                big.NewInt(400),
+					CreatedAtTimestamp:  big.NewInt(0),
+					ReplacedAtTimestamp: big.NewInt(0),
+				},
+				Signature: "0x20cbaf4cd93fbe19aafe4fb0c76eaa1828fb1d7918f2afdebd9fe0db8269c81d291ea72edecce1c038ce89f0ba13bb717779739b885b0d11d15a8045f701f3071b",
 			},
 		},
 	}

--- a/pkg/services/blockchain/eth/resolver_test.go
+++ b/pkg/services/blockchain/eth/resolver_test.go
@@ -363,9 +363,9 @@ func TestResolveSignature_Success(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedIdentityState, identityState)
 
-			primaryType := services.IDENTITY_STATE_TYPE
+			primaryType := services.IdentityStateType
 			if tt.expectedIdentityState.StateInfo == nil {
-				primaryType = services.GLOBAL_STATE_TYPE
+				primaryType = services.GlobalStateType
 			}
 
 			ok, _ := resolver.VerifyState(primaryType, identityState, *tt.userDID)

--- a/pkg/services/blockchain/eth/resolver_test.go
+++ b/pkg/services/blockchain/eth/resolver_test.go
@@ -215,6 +215,7 @@ func TestResolveSignature_Success(t *testing.T) {
 		opts                  *services.ResolverOpts
 		userDID               *w3c.DID
 		contractMock          func(c *cm.MockStateContract)
+		timeStamp             func() string
 		expectedIdentityState services.IdentityState
 	}{
 		{
@@ -238,6 +239,9 @@ func TestResolveSignature_Success(t *testing.T) {
 				stateInfo := abi.IStateStateInfo{Id: userID.BigInt(), State: big.NewInt(444), CreatedAtTimestamp: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
 				c.EXPECT().GetStateInfoByIdAndState(gomock.Any(), gomock.Any(), big.NewInt(5)).Return(stateInfo, nil)
 			},
+			timeStamp: func() string {
+				return "0"
+			},
 			expectedIdentityState: services.IdentityState{
 				StateInfo: &services.StateInfo{
 					ID:                  *userDID,
@@ -250,7 +254,7 @@ func TestResolveSignature_Success(t *testing.T) {
 					CreatedAtTimestamp:  big.NewInt(0),
 					ReplacedAtTimestamp: big.NewInt(0),
 				},
-				Signature: "0x840efe43812a09ea67648fa3fca8d148dab883ceed81eb484e79561f05522a0012bdff6a3119b23a99e128481f6ffde1ce8960b3d7968d34a513539112071ec61c",
+				Signature: "0xb35a80bf24a76c1f0b1d2026af586c5a424d456eaa496031be8ea36724f0b4121dea6259ebb126f4473698980311bda48678f220da4149975636d00c5b3a716b1b",
 			},
 		},
 		{
@@ -266,6 +270,9 @@ func TestResolveSignature_Success(t *testing.T) {
 				res := abi.IStateStateInfo{Id: userID.BigInt(), State: big.NewInt(555), CreatedAtTimestamp: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
 				c.EXPECT().GetStateInfoByIdAndState(gomock.Any(), gomock.Any(), big.NewInt(1)).Return(res, nil)
 			},
+			timeStamp: func() string {
+				return "0"
+			},
 			expectedIdentityState: services.IdentityState{
 				StateInfo: &services.StateInfo{
 					ID:                  *userDID,
@@ -274,7 +281,7 @@ func TestResolveSignature_Success(t *testing.T) {
 					ReplacedAtTimestamp: big.NewInt(0),
 				},
 				GistInfo:  nil,
-				Signature: "0x5f411887c018ed7438f3887167b23464e8807078d163185e043f7b3117a3b59106a5fae670451c17f43cdc9842c5abccc3210d3b7e7a4627c8ab840c0e480d711c",
+				Signature: "0x29c02ac82784594f9eca4194502ce3514414b02ac359277991f4af6cfcef1965497b07d288a841bd8a5f45bd8859e8259a6c19f722fe66707f1ebb160a82bcbe1b",
 			},
 		},
 		{
@@ -293,6 +300,9 @@ func TestResolveSignature_Success(t *testing.T) {
 				stateInfo := abi.IStateStateInfo{Id: userID.BigInt(), State: big.NewInt(555), CreatedAtTimestamp: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
 				c.EXPECT().GetStateInfoById(gomock.Any(), userID.BigInt()).Return(stateInfo, nil)
 			},
+			timeStamp: func() string {
+				return "0"
+			},
 			expectedIdentityState: services.IdentityState{
 				StateInfo: &services.StateInfo{
 					ID:                  *userDID,
@@ -305,7 +315,7 @@ func TestResolveSignature_Success(t *testing.T) {
 					CreatedAtTimestamp:  big.NewInt(0),
 					ReplacedAtTimestamp: big.NewInt(0),
 				},
-				Signature: "0xee0ba8b277b71b4b3e79c668d5e3de169e5e72f92b3bb4e8637e570ca6c810bd5684d01b9a9b7fbbead7528040715b77d9a8177aa3de72a589851cd252dd6a111b",
+				Signature: "0x01645122b7895740b445a8b2a149f853948af73f6ecec4061322ceaa5df45ce451ea151e8aec2c30bc30ef9175788fcd3e451d3faad483c071f81950b5984fda1c",
 			},
 		},
 		{
@@ -321,6 +331,9 @@ func TestResolveSignature_Success(t *testing.T) {
 				latestGistInfo := abi.IStateGistRootInfo{Root: big.NewInt(400), CreatedAtTimestamp: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
 				c.EXPECT().GetGISTRootInfo(gomock.Any(), latestGist).Return(latestGistInfo, nil)
 			},
+			timeStamp: func() string {
+				return "0"
+			},
 			expectedIdentityState: services.IdentityState{
 				StateInfo: nil,
 				GistInfo: &services.GistInfo{
@@ -328,7 +341,7 @@ func TestResolveSignature_Success(t *testing.T) {
 					CreatedAtTimestamp:  big.NewInt(0),
 					ReplacedAtTimestamp: big.NewInt(0),
 				},
-				Signature: "0x20cbaf4cd93fbe19aafe4fb0c76eaa1828fb1d7918f2afdebd9fe0db8269c81d291ea72edecce1c038ce89f0ba13bb717779739b885b0d11d15a8045f701f3071b",
+				Signature: "0xe3c17d6d39f96bc16738ce69897e5770abde25bb44e6b987b1279034820135f377350456a314ba39bb9c6292cc06d74d19cf577b0a31bf82de454ea30be1615b1b",
 			},
 		},
 	}
@@ -344,11 +357,11 @@ func TestResolveSignature_Success(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			stateContract := cm.NewMockStateContract(ctrl)
 			tt.contractMock(stateContract)
+			TimeStamp = tt.timeStamp
 			resolver := Resolver{state: stateContract, chainID: 1, walletKey: privateKeyHex}
 			identityState, err := resolver.Resolve(context.Background(), *tt.userDID, tt.opts)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedIdentityState, identityState)
-
 			verifyingContract := services.VerifyingContract{
 				ChainId: *tt.opts.VerifyingContractChainId,
 				Address: tt.opts.VerifyingContractAddress,

--- a/pkg/services/blockchain/eth/resolver_test.go
+++ b/pkg/services/blockchain/eth/resolver_test.go
@@ -231,20 +231,24 @@ func TestResolveSignature_Success(t *testing.T) {
 				}
 				userID, _ := core.IDFromDID(*userDID)
 				c.EXPECT().GetGISTProofByRoot(gomock.Any(), userID.BigInt(), big.NewInt(1)).Return(proof, nil)
-				gistInfo := abi.IStateGistRootInfo{Root: big.NewInt(555)}
+				gistInfo := abi.IStateGistRootInfo{Root: big.NewInt(555), CreatedAtTimestamp: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
 				c.EXPECT().GetGISTRootInfo(gomock.Any(), big.NewInt(4)).Return(gistInfo, nil)
-				stateInfo := abi.IStateStateInfo{Id: userID.BigInt(), State: big.NewInt(444)}
+				stateInfo := abi.IStateStateInfo{Id: userID.BigInt(), State: big.NewInt(444), CreatedAtTimestamp: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
 				c.EXPECT().GetStateInfoByIdAndState(gomock.Any(), gomock.Any(), big.NewInt(5)).Return(stateInfo, nil)
 			},
 			expectedIdentityState: services.IdentityState{
 				StateInfo: &services.StateInfo{
-					ID:    *userDID,
-					State: big.NewInt(444),
+					ID:                  *userDID,
+					State:               big.NewInt(444),
+					CreatedAtTimestamp:  big.NewInt(0),
+					ReplacedAtTimestamp: big.NewInt(0),
 				},
 				GistInfo: &services.GistInfo{
-					Root: big.NewInt(555),
+					Root:                big.NewInt(555),
+					CreatedAtTimestamp:  big.NewInt(0),
+					ReplacedAtTimestamp: big.NewInt(0),
 				},
-				Signature: "0x028ca69378ed198806eecebc722d1bfcf8fb5ca9232274f2403c2d6b4aa3199902555c672c474faec318de2d6974898d542f18f99f884000a22f29d0c2956d291c",
+				Signature: "0x840efe43812a09ea67648fa3fca8d148dab883ceed81eb484e79561f05522a0012bdff6a3119b23a99e128481f6ffde1ce8960b3d7968d34a513539112071ec61c",
 			},
 		},
 		{
@@ -257,16 +261,18 @@ func TestResolveSignature_Success(t *testing.T) {
 			userDID: userDID,
 			contractMock: func(c *cm.MockStateContract) {
 				userID, _ := core.IDFromDID(*userDID)
-				res := abi.IStateStateInfo{Id: userID.BigInt(), State: big.NewInt(555)}
+				res := abi.IStateStateInfo{Id: userID.BigInt(), State: big.NewInt(555), CreatedAtTimestamp: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
 				c.EXPECT().GetStateInfoByIdAndState(gomock.Any(), gomock.Any(), big.NewInt(1)).Return(res, nil)
 			},
 			expectedIdentityState: services.IdentityState{
 				StateInfo: &services.StateInfo{
-					ID:    *userDID,
-					State: big.NewInt(555),
+					ID:                  *userDID,
+					State:               big.NewInt(555),
+					CreatedAtTimestamp:  big.NewInt(0),
+					ReplacedAtTimestamp: big.NewInt(0),
 				},
 				GistInfo:  nil,
-				Signature: "0xb23932bd8f5fc4674583b41ceade5aeb6113ea22b3f330e4deaaa432dfed9ab853dac55f531abd90a8c89b573444aeb974305c3a8aac3bc201531aad34383fbb1c",
+				Signature: "0x5f411887c018ed7438f3887167b23464e8807078d163185e043f7b3117a3b59106a5fae670451c17f43cdc9842c5abccc3210d3b7e7a4627c8ab840c0e480d711c",
 			},
 		},
 		{
@@ -280,20 +286,24 @@ func TestResolveSignature_Success(t *testing.T) {
 				userID, _ := core.IDFromDID(*userDID)
 				latestGist := big.NewInt(100)
 				c.EXPECT().GetGISTRoot(gomock.Any()).Return(latestGist, nil)
-				latestGistInfo := abi.IStateGistRootInfo{Root: big.NewInt(400)}
+				latestGistInfo := abi.IStateGistRootInfo{Root: big.NewInt(400), CreatedAtTimestamp: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
 				c.EXPECT().GetGISTRootInfo(gomock.Any(), latestGist).Return(latestGistInfo, nil)
-				stateInfo := abi.IStateStateInfo{Id: userID.BigInt(), State: big.NewInt(555)}
+				stateInfo := abi.IStateStateInfo{Id: userID.BigInt(), State: big.NewInt(555), CreatedAtTimestamp: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
 				c.EXPECT().GetStateInfoById(gomock.Any(), userID.BigInt()).Return(stateInfo, nil)
 			},
 			expectedIdentityState: services.IdentityState{
 				StateInfo: &services.StateInfo{
-					ID:    *userDID,
-					State: big.NewInt(555),
+					ID:                  *userDID,
+					State:               big.NewInt(555),
+					CreatedAtTimestamp:  big.NewInt(0),
+					ReplacedAtTimestamp: big.NewInt(0),
 				},
 				GistInfo: &services.GistInfo{
-					Root: big.NewInt(400),
+					Root:                big.NewInt(400),
+					CreatedAtTimestamp:  big.NewInt(0),
+					ReplacedAtTimestamp: big.NewInt(0),
 				},
-				Signature: "0x5a9ea69f9311ac800a3fc2375cf6fa4d4646b5b2b55219f934755177c93d367a152e4ab7585600598f280485c41471a782dc6ef3e1fd235bd48e4441446ec24d1b",
+				Signature: "0xee0ba8b277b71b4b3e79c668d5e3de169e5e72f92b3bb4e8637e570ca6c810bd5684d01b9a9b7fbbead7528040715b77d9a8177aa3de72a589851cd252dd6a111b",
 			},
 		},
 	}
@@ -314,7 +324,12 @@ func TestResolveSignature_Success(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedIdentityState, identityState)
 
-			ok, _ := resolver.VerifyIdentityState(identityState, *tt.userDID, *tt.opts.VerifyingContractChainId, tt.opts.VerifyingContractAddress)
+			verifyingContract := services.VerifyingContract{
+				ChainId: *tt.opts.VerifyingContractChainId,
+				Address: tt.opts.VerifyingContractAddress,
+			}
+
+			ok, _ := resolver.VerifyIdentityState(identityState, *tt.userDID, verifyingContract)
 			require.Equal(t, true, ok)
 			ctrl.Finish()
 		})

--- a/pkg/services/blockchain/eth/resolver_test.go
+++ b/pkg/services/blockchain/eth/resolver_test.go
@@ -240,7 +240,7 @@ func TestResolveSignature_Success(t *testing.T) {
 				GistInfo: &services.GistInfo{
 					Root: big.NewInt(555),
 				},
-				Signature: "0xd0488105cd2af066b7aa7cb36091cd6a9328b8c365df0914e7392a721918c76d42b644ae364258072a5436706bdbd65d603fd657814d17dcabba3c7bd31c7a411b",
+				Signature: "0xfd0b364ceb42b65824daa75c5f0c1932a9e3430e871e3810b8155244d7ac67772b02b8c24356180d5112035e84536bdf2de4ea7d0116967b3331fc95b50a2a961b",
 			},
 		},
 		{
@@ -260,7 +260,7 @@ func TestResolveSignature_Success(t *testing.T) {
 					State: big.NewInt(555),
 				},
 				GistInfo:  nil,
-				Signature: "0x0ee7c23eb141aa0d7e4a47469de211ec6d3ae01cb0850786112db15d5d7673164c2c9a3e1f3dc880cea4bf280e3bbeb52f4750f4d32152c20dcdefadc25212411c",
+				Signature: "0x0ec2b122b0f53aed76a006f9d9dde7e0ce0b67371d70983379e8f0ee99c8fae74fdc58687259221f7f7ac5ad4bf1654be189084507cd7f309565af1dc82322861c",
 			},
 		},
 		{
@@ -284,7 +284,7 @@ func TestResolveSignature_Success(t *testing.T) {
 				GistInfo: &services.GistInfo{
 					Root: big.NewInt(400),
 				},
-				Signature: "0xdb4a1e6e5cb5dce2c9815cb612edc19e7bcd655f5e1c72370753c4d2df9ea11a698a970f99915847e1e0146ef7f36adb97088d9f7143f7293af72c05fd3e4d991b",
+				Signature: "0x5e44cee08048ec667ba6480f1c969ae68a41d8704fd4a778fb8bc16868def4ef0622774d88e3ec898b5e2f51ac46b621da5ae060c205778f19895c6f038b90331c",
 			},
 		},
 	}

--- a/pkg/services/blockchain/eth/resolver_test.go
+++ b/pkg/services/blockchain/eth/resolver_test.go
@@ -253,7 +253,7 @@ func TestResolveSignature_Success(t *testing.T) {
 					ReplacedByRoot:      big.NewInt(0),
 					ReplacedAtTimestamp: big.NewInt(0),
 				},
-				Signature: "0xedbe6cd15241ee8cd6a76446fbdf44e90df28c42eaff606ea6cd55d97158c036187aad5556753bd7a306cd71bdaddfac7af7f4127b66e4159d3d6d69548ba4de1c",
+				Signature: "0x6276946bac246584ed6eaa2d5e43be5147e67cc7aa3b969c82bb9b1670e8de8b7f7410286f25d6bee4330b4bc260286cf8505358ffa29c8e677e4f05d78acf131c",
 			},
 		},
 		{
@@ -280,7 +280,7 @@ func TestResolveSignature_Success(t *testing.T) {
 					ReplacedAtTimestamp: big.NewInt(0),
 				},
 				GistInfo:  nil,
-				Signature: "0x3fe7236be270e37125e265ced2b5be614909015d9636c7bca14e9adca38a9b5e789cedaa32edec24b9c1226df1ed4d86dafa8ab1587fb6d29b07e040dfb1b2861c",
+				Signature: "0xdd07cd99ee8aa853c3e942aa5d57bfb844cae3db35fe29e8fc635ff4b2f5377d4b3c65f270474e6c5931b3d77f536233bc56d63172da8dba188f1f6fa51a10cb1c",
 			},
 		},
 		{
@@ -315,7 +315,7 @@ func TestResolveSignature_Success(t *testing.T) {
 					ReplacedByRoot:      big.NewInt(0),
 					ReplacedAtTimestamp: big.NewInt(0),
 				},
-				Signature: "0x8a39cf242b4474f62ad3579c31ae42e5981c0237fe6232513528f2731defc3db553535f23895a7d444d31a7643924071ce34f8a3dd308bfcbf1d4a90eb6ee5571c",
+				Signature: "0xdd07cd99ee8aa853c3e942aa5d57bfb844cae3db35fe29e8fc635ff4b2f5377d4b3c65f270474e6c5931b3d77f536233bc56d63172da8dba188f1f6fa51a10cb1c",
 			},
 		},
 		{
@@ -341,7 +341,7 @@ func TestResolveSignature_Success(t *testing.T) {
 					ReplacedByRoot:      big.NewInt(0),
 					ReplacedAtTimestamp: big.NewInt(0),
 				},
-				Signature: "0xb38e057dddbb4636ecf7a8f9d1eefc352ee0c8e395857462859509d9e40c68bf731e285117f571f5805bcbc6fb13a16fadd83d963d8a3918a793cf8877a363481b",
+				Signature: "0xe64e080d08b948e5303b49288f1ff599df5b21fd20d7a944026a17e69f860e21662538ec1f8cba2f4a76e7c25d0f5cf506dc16bbc3148158ed81dd899528c69f1c",
 			},
 		},
 	}
@@ -363,7 +363,12 @@ func TestResolveSignature_Success(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedIdentityState, identityState)
 
-			ok, _ := resolver.VerifyIdentityState(identityState, *tt.userDID)
+			primaryType := services.IDENTITY_STATE_TYPE
+			if tt.expectedIdentityState.StateInfo == nil {
+				primaryType = services.GLOBAL_STATE_TYPE
+			}
+
+			ok, _ := resolver.VerifyState(primaryType, identityState, *tt.userDID)
 			require.Equal(t, true, ok)
 			ctrl.Finish()
 		})

--- a/pkg/services/blockchain/eth/resolver_test.go
+++ b/pkg/services/blockchain/eth/resolver_test.go
@@ -206,8 +206,6 @@ func TestNotFoundErr(t *testing.T) {
 }
 
 func TestResolveSignature_Success(t *testing.T) {
-	verifyingContractChainId := new(int)
-	*verifyingContractChainId = 1
 	userEmptyDID, _ := w3c.ParseDID("did:polygonid:polygon:amoy:000000000000000000000000000000000000000000")
 
 	tests := []struct {
@@ -221,9 +219,8 @@ func TestResolveSignature_Success(t *testing.T) {
 		{
 			name: "resolve identity state by gist",
 			opts: &services.ResolverOpts{
-				GistRoot:                 big.NewInt(1),
-				VerifyingContractChainId: verifyingContractChainId,
-				VerifyingContractAddress: "0x0000000000000000000000000000000000000000",
+				GistRoot:  big.NewInt(1),
+				Signature: "EthereumEip712Signature2021",
 			},
 			userDID: userDID,
 			contractMock: func(c *cm.MockStateContract) {
@@ -254,15 +251,14 @@ func TestResolveSignature_Success(t *testing.T) {
 					CreatedAtTimestamp:  big.NewInt(0),
 					ReplacedAtTimestamp: big.NewInt(0),
 				},
-				Signature: "0xb35a80bf24a76c1f0b1d2026af586c5a424d456eaa496031be8ea36724f0b4121dea6259ebb126f4473698980311bda48678f220da4149975636d00c5b3a716b1b",
+				Signature: "0xe63151912749d0cae7fea6a13dda6d54061626cc03a79dac46b6a11b3259c6c335d8266f09eaf070a31c8a23765fb01e3c8bf927f5ab25346f743ae309eabc801c",
 			},
 		},
 		{
 			name: "resolve identity state by state",
 			opts: &services.ResolverOpts{
-				State:                    big.NewInt(1),
-				VerifyingContractChainId: verifyingContractChainId,
-				VerifyingContractAddress: "0x0000000000000000000000000000000000000000",
+				State:     big.NewInt(1),
+				Signature: "EthereumEip712Signature2021",
 			},
 			userDID: userDID,
 			contractMock: func(c *cm.MockStateContract) {
@@ -281,14 +277,13 @@ func TestResolveSignature_Success(t *testing.T) {
 					ReplacedAtTimestamp: big.NewInt(0),
 				},
 				GistInfo:  nil,
-				Signature: "0x29c02ac82784594f9eca4194502ce3514414b02ac359277991f4af6cfcef1965497b07d288a841bd8a5f45bd8859e8259a6c19f722fe66707f1ebb160a82bcbe1b",
+				Signature: "0x3dce5819f16b5225bbe9ec3ce144b45654119f4cfdff2f9e8f5d33a0fc3790de570dfacdc304ee217b43952c9393425fc45f5abc9e9f7e5b63196479319eb62c1b",
 			},
 		},
 		{
 			name: "resolve latest state",
 			opts: &services.ResolverOpts{
-				VerifyingContractChainId: verifyingContractChainId,
-				VerifyingContractAddress: "0x0000000000000000000000000000000000000000",
+				Signature: "EthereumEip712Signature2021",
 			},
 			userDID: userDID,
 			contractMock: func(c *cm.MockStateContract) {
@@ -315,15 +310,14 @@ func TestResolveSignature_Success(t *testing.T) {
 					CreatedAtTimestamp:  big.NewInt(0),
 					ReplacedAtTimestamp: big.NewInt(0),
 				},
-				Signature: "0x01645122b7895740b445a8b2a149f853948af73f6ecec4061322ceaa5df45ce451ea151e8aec2c30bc30ef9175788fcd3e451d3faad483c071f81950b5984fda1c",
+				Signature: "0x866206f5be01973be72631fd9931d8ccc7d6e8612f799dc39ff495d1e3a975af7c81c0e4fc13e50f4177fbc637e81ca546ee2906eccf1dfa96687fff05bd49831c",
 			},
 		},
 		{
 			name: "resolve only gist",
 			opts: &services.ResolverOpts{
-				GistRoot:                 big.NewInt(400),
-				VerifyingContractChainId: verifyingContractChainId,
-				VerifyingContractAddress: "0x0000000000000000000000000000000000000000",
+				GistRoot:  big.NewInt(400),
+				Signature: "EthereumEip712Signature2021",
 			},
 			userDID: userEmptyDID,
 			contractMock: func(c *cm.MockStateContract) {
@@ -341,7 +335,7 @@ func TestResolveSignature_Success(t *testing.T) {
 					CreatedAtTimestamp:  big.NewInt(0),
 					ReplacedAtTimestamp: big.NewInt(0),
 				},
-				Signature: "0xe3c17d6d39f96bc16738ce69897e5770abde25bb44e6b987b1279034820135f377350456a314ba39bb9c6292cc06d74d19cf577b0a31bf82de454ea30be1615b1b",
+				Signature: "0xec3a8bd564247bed3c16f719d499e02d4914a8fa10704a8f3dcae75ca393b3ae47c3f147355f5476cb495b8e0463fd128da2795c02bd9420f8071d93652d13b81b",
 			},
 		},
 	}
@@ -362,12 +356,8 @@ func TestResolveSignature_Success(t *testing.T) {
 			identityState, err := resolver.Resolve(context.Background(), *tt.userDID, tt.opts)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedIdentityState, identityState)
-			verifyingContract := services.VerifyingContract{
-				ChainId: *tt.opts.VerifyingContractChainId,
-				Address: tt.opts.VerifyingContractAddress,
-			}
 
-			ok, _ := resolver.VerifyIdentityState(identityState, *tt.userDID, verifyingContract)
+			ok, _ := resolver.VerifyIdentityState(identityState, *tt.userDID)
 			require.Equal(t, true, ok)
 			ctrl.Finish()
 		})

--- a/pkg/services/blockchain/eth/resolver_test.go
+++ b/pkg/services/blockchain/eth/resolver_test.go
@@ -231,9 +231,9 @@ func TestResolveSignature_Success(t *testing.T) {
 				}
 				userID, _ := core.IDFromDID(*userDID)
 				c.EXPECT().GetGISTProofByRoot(gomock.Any(), userID.BigInt(), big.NewInt(1)).Return(proof, nil)
-				gistInfo := abi.IStateGistRootInfo{Root: big.NewInt(555), CreatedAtTimestamp: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
+				gistInfo := abi.IStateGistRootInfo{Root: big.NewInt(555), CreatedAtTimestamp: big.NewInt(0), ReplacedByRoot: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
 				c.EXPECT().GetGISTRootInfo(gomock.Any(), big.NewInt(4)).Return(gistInfo, nil)
-				stateInfo := abi.IStateStateInfo{Id: userID.BigInt(), State: big.NewInt(444), CreatedAtTimestamp: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
+				stateInfo := abi.IStateStateInfo{Id: userID.BigInt(), State: big.NewInt(444), CreatedAtTimestamp: big.NewInt(0), ReplacedByState: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
 				c.EXPECT().GetStateInfoByIdAndState(gomock.Any(), gomock.Any(), big.NewInt(5)).Return(stateInfo, nil)
 			},
 			timeStamp: func() string {
@@ -244,14 +244,16 @@ func TestResolveSignature_Success(t *testing.T) {
 					ID:                  *userDID,
 					State:               big.NewInt(444),
 					CreatedAtTimestamp:  big.NewInt(0),
+					ReplacedByState:     big.NewInt(0),
 					ReplacedAtTimestamp: big.NewInt(0),
 				},
 				GistInfo: &services.GistInfo{
 					Root:                big.NewInt(555),
 					CreatedAtTimestamp:  big.NewInt(0),
+					ReplacedByRoot:      big.NewInt(0),
 					ReplacedAtTimestamp: big.NewInt(0),
 				},
-				Signature: "0xe63151912749d0cae7fea6a13dda6d54061626cc03a79dac46b6a11b3259c6c335d8266f09eaf070a31c8a23765fb01e3c8bf927f5ab25346f743ae309eabc801c",
+				Signature: "0xedbe6cd15241ee8cd6a76446fbdf44e90df28c42eaff606ea6cd55d97158c036187aad5556753bd7a306cd71bdaddfac7af7f4127b66e4159d3d6d69548ba4de1c",
 			},
 		},
 		{
@@ -263,7 +265,7 @@ func TestResolveSignature_Success(t *testing.T) {
 			userDID: userDID,
 			contractMock: func(c *cm.MockStateContract) {
 				userID, _ := core.IDFromDID(*userDID)
-				res := abi.IStateStateInfo{Id: userID.BigInt(), State: big.NewInt(555), CreatedAtTimestamp: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
+				res := abi.IStateStateInfo{Id: userID.BigInt(), State: big.NewInt(555), CreatedAtTimestamp: big.NewInt(0), ReplacedByState: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
 				c.EXPECT().GetStateInfoByIdAndState(gomock.Any(), gomock.Any(), big.NewInt(1)).Return(res, nil)
 			},
 			timeStamp: func() string {
@@ -274,10 +276,11 @@ func TestResolveSignature_Success(t *testing.T) {
 					ID:                  *userDID,
 					State:               big.NewInt(555),
 					CreatedAtTimestamp:  big.NewInt(0),
+					ReplacedByState:     big.NewInt(0),
 					ReplacedAtTimestamp: big.NewInt(0),
 				},
 				GistInfo:  nil,
-				Signature: "0x3dce5819f16b5225bbe9ec3ce144b45654119f4cfdff2f9e8f5d33a0fc3790de570dfacdc304ee217b43952c9393425fc45f5abc9e9f7e5b63196479319eb62c1b",
+				Signature: "0x3fe7236be270e37125e265ced2b5be614909015d9636c7bca14e9adca38a9b5e789cedaa32edec24b9c1226df1ed4d86dafa8ab1587fb6d29b07e040dfb1b2861c",
 			},
 		},
 		{
@@ -290,9 +293,9 @@ func TestResolveSignature_Success(t *testing.T) {
 				userID, _ := core.IDFromDID(*userDID)
 				latestGist := big.NewInt(100)
 				c.EXPECT().GetGISTRoot(gomock.Any()).Return(latestGist, nil)
-				latestGistInfo := abi.IStateGistRootInfo{Root: big.NewInt(400), CreatedAtTimestamp: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
+				latestGistInfo := abi.IStateGistRootInfo{Root: big.NewInt(400), CreatedAtTimestamp: big.NewInt(0), ReplacedByRoot: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
 				c.EXPECT().GetGISTRootInfo(gomock.Any(), latestGist).Return(latestGistInfo, nil)
-				stateInfo := abi.IStateStateInfo{Id: userID.BigInt(), State: big.NewInt(555), CreatedAtTimestamp: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
+				stateInfo := abi.IStateStateInfo{Id: userID.BigInt(), State: big.NewInt(555), CreatedAtTimestamp: big.NewInt(0), ReplacedByState: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
 				c.EXPECT().GetStateInfoById(gomock.Any(), userID.BigInt()).Return(stateInfo, nil)
 			},
 			timeStamp: func() string {
@@ -303,14 +306,16 @@ func TestResolveSignature_Success(t *testing.T) {
 					ID:                  *userDID,
 					State:               big.NewInt(555),
 					CreatedAtTimestamp:  big.NewInt(0),
+					ReplacedByState:     big.NewInt(0),
 					ReplacedAtTimestamp: big.NewInt(0),
 				},
 				GistInfo: &services.GistInfo{
 					Root:                big.NewInt(400),
 					CreatedAtTimestamp:  big.NewInt(0),
+					ReplacedByRoot:      big.NewInt(0),
 					ReplacedAtTimestamp: big.NewInt(0),
 				},
-				Signature: "0x866206f5be01973be72631fd9931d8ccc7d6e8612f799dc39ff495d1e3a975af7c81c0e4fc13e50f4177fbc637e81ca546ee2906eccf1dfa96687fff05bd49831c",
+				Signature: "0x8a39cf242b4474f62ad3579c31ae42e5981c0237fe6232513528f2731defc3db553535f23895a7d444d31a7643924071ce34f8a3dd308bfcbf1d4a90eb6ee5571c",
 			},
 		},
 		{
@@ -322,7 +327,7 @@ func TestResolveSignature_Success(t *testing.T) {
 			userDID: userEmptyDID,
 			contractMock: func(c *cm.MockStateContract) {
 				latestGist := big.NewInt(400)
-				latestGistInfo := abi.IStateGistRootInfo{Root: big.NewInt(400), CreatedAtTimestamp: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
+				latestGistInfo := abi.IStateGistRootInfo{Root: big.NewInt(400), CreatedAtTimestamp: big.NewInt(0), ReplacedByRoot: big.NewInt(0), ReplacedAtTimestamp: big.NewInt(0)}
 				c.EXPECT().GetGISTRootInfo(gomock.Any(), latestGist).Return(latestGistInfo, nil)
 			},
 			timeStamp: func() string {
@@ -333,9 +338,10 @@ func TestResolveSignature_Success(t *testing.T) {
 				GistInfo: &services.GistInfo{
 					Root:                big.NewInt(400),
 					CreatedAtTimestamp:  big.NewInt(0),
+					ReplacedByRoot:      big.NewInt(0),
 					ReplacedAtTimestamp: big.NewInt(0),
 				},
-				Signature: "0xec3a8bd564247bed3c16f719d499e02d4914a8fa10704a8f3dcae75ca393b3ae47c3f147355f5476cb495b8e0463fd128da2795c02bd9420f8071d93652d13b81b",
+				Signature: "0xb38e057dddbb4636ecf7a8f9d1eefc352ee0c8e395857462859509d9e40c68bf731e285117f571f5805bcbc6fb13a16fadd83d963d8a3918a793cf8877a363481b",
 			},
 		},
 	}

--- a/pkg/services/blockchain/eth/resolver_test.go
+++ b/pkg/services/blockchain/eth/resolver_test.go
@@ -206,6 +206,8 @@ func TestNotFoundErr(t *testing.T) {
 }
 
 func TestResolveSignature_Success(t *testing.T) {
+	verifyingContractChainId := new(int)
+	*verifyingContractChainId = 1
 	tests := []struct {
 		name                  string
 		opts                  *services.ResolverOpts
@@ -216,7 +218,9 @@ func TestResolveSignature_Success(t *testing.T) {
 		{
 			name: "resolve identity state by gist",
 			opts: &services.ResolverOpts{
-				GistRoot: big.NewInt(1),
+				GistRoot:                 big.NewInt(1),
+				VerifyingContractChainId: verifyingContractChainId,
+				VerifyingContractAddress: "0x0000000000000000000000000000000000000000",
 			},
 			userDID: userDID,
 			contractMock: func(c *cm.MockStateContract) {
@@ -240,13 +244,15 @@ func TestResolveSignature_Success(t *testing.T) {
 				GistInfo: &services.GistInfo{
 					Root: big.NewInt(555),
 				},
-				Signature: "0xfd0b364ceb42b65824daa75c5f0c1932a9e3430e871e3810b8155244d7ac67772b02b8c24356180d5112035e84536bdf2de4ea7d0116967b3331fc95b50a2a961b",
+				Signature: "0x028ca69378ed198806eecebc722d1bfcf8fb5ca9232274f2403c2d6b4aa3199902555c672c474faec318de2d6974898d542f18f99f884000a22f29d0c2956d291c",
 			},
 		},
 		{
 			name: "resolve identity state by state",
 			opts: &services.ResolverOpts{
-				State: big.NewInt(1),
+				State:                    big.NewInt(1),
+				VerifyingContractChainId: verifyingContractChainId,
+				VerifyingContractAddress: "0x0000000000000000000000000000000000000000",
 			},
 			userDID: userDID,
 			contractMock: func(c *cm.MockStateContract) {
@@ -260,12 +266,15 @@ func TestResolveSignature_Success(t *testing.T) {
 					State: big.NewInt(555),
 				},
 				GistInfo:  nil,
-				Signature: "0x0ec2b122b0f53aed76a006f9d9dde7e0ce0b67371d70983379e8f0ee99c8fae74fdc58687259221f7f7ac5ad4bf1654be189084507cd7f309565af1dc82322861c",
+				Signature: "0xb23932bd8f5fc4674583b41ceade5aeb6113ea22b3f330e4deaaa432dfed9ab853dac55f531abd90a8c89b573444aeb974305c3a8aac3bc201531aad34383fbb1c",
 			},
 		},
 		{
-			name:    "resolve latest state",
-			opts:    &services.ResolverOpts{},
+			name: "resolve latest state",
+			opts: &services.ResolverOpts{
+				VerifyingContractChainId: verifyingContractChainId,
+				VerifyingContractAddress: "0x0000000000000000000000000000000000000000",
+			},
 			userDID: userDID,
 			contractMock: func(c *cm.MockStateContract) {
 				userID, _ := core.IDFromDID(*userDID)
@@ -284,7 +293,7 @@ func TestResolveSignature_Success(t *testing.T) {
 				GistInfo: &services.GistInfo{
 					Root: big.NewInt(400),
 				},
-				Signature: "0x5e44cee08048ec667ba6480f1c969ae68a41d8704fd4a778fb8bc16868def4ef0622774d88e3ec898b5e2f51ac46b621da5ae060c205778f19895c6f038b90331c",
+				Signature: "0x5a9ea69f9311ac800a3fc2375cf6fa4d4646b5b2b55219f934755177c93d367a152e4ab7585600598f280485c41471a782dc6ef3e1fd235bd48e4441446ec24d1b",
 			},
 		},
 	}
@@ -305,7 +314,7 @@ func TestResolveSignature_Success(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedIdentityState, identityState)
 
-			ok, _ := resolver.VerifyIdentityState(identityState, *tt.userDID)
+			ok, _ := resolver.VerifyIdentityState(identityState, *tt.userDID, *tt.opts.VerifyingContractChainId, tt.opts.VerifyingContractAddress)
 			require.Equal(t, true, ok)
 			ctrl.Finish()
 		})

--- a/pkg/services/did.go
+++ b/pkg/services/did.go
@@ -142,7 +142,11 @@ func (d *DidDocumentServices) GetDidDocument(ctx context.Context, did string, op
 	walletAddress, err := resolver.WalletAddress()
 
 	if err == nil && opts.Signature != "" {
-		eip712TypedData, err := resolver.TypedData(*userDID, identityState, walletAddress)
+		primaryType := IDENTITY_STATE_TYPE
+		if userDID.IDStrings[2] == "000000000000000000000000000000000000000000" {
+			primaryType = GLOBAL_STATE_TYPE
+		}
+		eip712TypedData, err := resolver.TypedData(primaryType, *userDID, identityState, walletAddress)
 		if err != nil {
 			return nil, fmt.Errorf("invalid typed data: %v", err)
 		}
@@ -151,7 +155,7 @@ func (d *DidDocumentServices) GetDidDocument(ctx context.Context, did string, op
 			Type:               document.EthereumEip712SignatureProof2021Type,
 			ProofPursopose:     "assertionMethod",
 			ProofValue:         identityState.Signature,
-			VerificationMethod: fmt.Sprintf("did:pkh:eip155:%s:%s#blockchainAccountId", strings.Split(chainIDStateAddress, ":")[0], walletAddress),
+			VerificationMethod: fmt.Sprintf("did:pkh:eip155:0:%s#blockchainAccountId", walletAddress),
 			Eip712:             eip712TypedData,
 			Created:            time.Now(),
 		}

--- a/pkg/services/did.go
+++ b/pkg/services/did.go
@@ -133,24 +133,17 @@ func (d *DidDocumentServices) GetDidDocument(ctx context.Context, did string, op
 	walletAddress, err := resolver.WalletAddress()
 
 	if err == nil {
-		stateInfoState := ""
-		gistInfoRoot := ""
-		if identityState.StateInfo != nil {
-			stateInfoState = identityState.StateInfo.State.String()
-		}
-
-		if identityState.GistInfo != nil {
-			gistInfoRoot = identityState.GistInfo.Root.String()
-		}
-		verifyingContractChainId := 0
 		if opts.VerifyingContractChainId == nil {
 			return nil, errors.New("error verifying contract chainId is not set")
 		}
-		verifyingContractChainId = *opts.VerifyingContractChainId
 		if opts.VerifyingContractAddress == "" {
 			return nil, errors.New("error verifying contract address is not set")
 		}
-		eip712TypedData, err := resolver.TypedData(verifyingContractChainId, opts.VerifyingContractAddress, *userDID, stateInfoState, gistInfoRoot, walletAddress)
+		verifyingContract := VerifyingContract{
+			ChainId: *opts.VerifyingContractChainId,
+			Address: opts.VerifyingContractAddress,
+		}
+		eip712TypedData, err := resolver.TypedData(verifyingContract, *userDID, identityState, walletAddress)
 		if err != nil {
 			return nil, fmt.Errorf("invalid typed data: %v", err)
 		}

--- a/pkg/services/did.go
+++ b/pkg/services/did.go
@@ -55,7 +55,7 @@ func (d *DidDocumentServices) GetDidDocument(ctx context.Context, did string, op
 		blockchain = userDID.IDStrings[0]
 		network = userDID.IDStrings[1]
 	} else {
-		userID, err := core.IDFromDID(*userDID)
+		userID, err = core.IDFromDID(*userDID)
 		errResolution, err = expectedError(err)
 		if err != nil {
 			return errResolution, err
@@ -110,7 +110,7 @@ func (d *DidDocumentServices) GetDidDocument(ctx context.Context, did string, op
 
 	chainIDStateAddress := resolver.BlockchainID()
 
-	if err == nil {
+	if err == nil && userDID.IDStrings[2] != "000000000000000000000000000000000000000000" {
 		addressString := fmt.Sprintf("%x", addr)
 		blockchainAccountID := fmt.Sprintf("eip155:%s:0x%s", strings.Split(chainIDStateAddress, ":")[0], addressString)
 		didResolution.DidDocument.VerificationMethod = append(

--- a/pkg/services/did.go
+++ b/pkg/services/did.go
@@ -161,7 +161,6 @@ func (d *DidDocumentServices) GetDidDocument(ctx context.Context, did string, op
 		}
 
 		didResolution.DidResolutionMetadata.Context = document.DidResolutionMetadataSigContext()
-		didResolution.DidResolutionMetadata.Type = document.Iden3ResolutionMetadataType
 		didResolution.DidResolutionMetadata.Proof = append(didResolution.DidResolutionMetadata.Proof, eip712Proof)
 	}
 

--- a/pkg/services/did.go
+++ b/pkg/services/did.go
@@ -26,10 +26,9 @@ type DidDocumentServices struct {
 }
 
 type ResolverOpts struct {
-	State                    *big.Int
-	GistRoot                 *big.Int
-	VerifyingContractChainId *int
-	VerifyingContractAddress string
+	State     *big.Int
+	GistRoot  *big.Int
+	Signature string
 }
 
 func NewDidDocumentServices(resolvers *ResolverRegistry, registry *ens.Registry) *DidDocumentServices {
@@ -142,12 +141,8 @@ func (d *DidDocumentServices) GetDidDocument(ctx context.Context, did string, op
 
 	walletAddress, err := resolver.WalletAddress()
 
-	if err == nil && opts.VerifyingContractChainId != nil && opts.VerifyingContractAddress != "" {
-		verifyingContract := VerifyingContract{
-			ChainId: *opts.VerifyingContractChainId,
-			Address: opts.VerifyingContractAddress,
-		}
-		eip712TypedData, err := resolver.TypedData(verifyingContract, *userDID, identityState, walletAddress)
+	if err == nil && opts.Signature != "" {
+		eip712TypedData, err := resolver.TypedData(*userDID, identityState, walletAddress)
 		if err != nil {
 			return nil, fmt.Errorf("invalid typed data: %v", err)
 		}

--- a/pkg/services/did.go
+++ b/pkg/services/did.go
@@ -142,9 +142,9 @@ func (d *DidDocumentServices) GetDidDocument(ctx context.Context, did string, op
 	walletAddress, err := resolver.WalletAddress()
 
 	if err == nil && opts.Signature != "" {
-		primaryType := IDENTITY_STATE_TYPE
+		primaryType := IdentityStateType
 		if userDID.IDStrings[2] == "000000000000000000000000000000000000000000" {
-			primaryType = GLOBAL_STATE_TYPE
+			primaryType = GlobalStateType
 		}
 		eip712TypedData, err := resolver.TypedData(primaryType, *userDID, identityState, walletAddress)
 		if err != nil {

--- a/pkg/services/did.go
+++ b/pkg/services/did.go
@@ -123,6 +123,7 @@ func (d *DidDocumentServices) GetDidDocument(ctx context.Context, did string, op
 				Published: &isPublished,
 				Info:      info,
 				Global:    gist,
+				Signature: identityState.Signature,
 			},
 		},
 	)

--- a/pkg/services/did.go
+++ b/pkg/services/did.go
@@ -48,25 +48,35 @@ func (d *DidDocumentServices) GetDidDocument(ctx context.Context, did string, op
 		return errResolution, err
 	}
 
-	userID, err := core.IDFromDID(*userDID)
-	errResolution, err = expectedError(err)
-	if err != nil {
-		return errResolution, err
+	blockchain := ""
+	network := ""
+	userID := core.ID{}
+	if userDID.IDStrings[2] == "000000000000000000000000000000000000000000" {
+		blockchain = userDID.IDStrings[0]
+		network = userDID.IDStrings[1]
+	} else {
+		userID, err := core.IDFromDID(*userDID)
+		errResolution, err = expectedError(err)
+		if err != nil {
+			return errResolution, err
+		}
+
+		b, err := core.BlockchainFromID(userID)
+		errResolution, err = expectedError(err)
+		if err != nil {
+			return errResolution, err
+		}
+
+		n, err := core.NetworkIDFromID(userID)
+		errResolution, err = expectedError(err)
+		if err != nil {
+			return errResolution, err
+		}
+		blockchain = string(b)
+		network = string(n)
 	}
 
-	b, err := core.BlockchainFromID(userID)
-	errResolution, err = expectedError(err)
-	if err != nil {
-		return errResolution, err
-	}
-
-	n, err := core.NetworkIDFromID(userID)
-	errResolution, err = expectedError(err)
-	if err != nil {
-		return errResolution, err
-	}
-
-	resolver, err := d.resolvers.GetResolverByNetwork(string(b), string(n))
+	resolver, err := d.resolvers.GetResolverByNetwork(blockchain, network)
 	errResolution, err = expectedError(err)
 	if err != nil {
 		return errResolution, err

--- a/pkg/services/did.go
+++ b/pkg/services/did.go
@@ -26,8 +26,10 @@ type DidDocumentServices struct {
 }
 
 type ResolverOpts struct {
-	State    *big.Int
-	GistRoot *big.Int
+	State                    *big.Int
+	GistRoot                 *big.Int
+	VerifyingContractChainId *int
+	VerifyingContractAddress string
 }
 
 func NewDidDocumentServices(resolvers *ResolverRegistry, registry *ens.Registry) *DidDocumentServices {
@@ -140,8 +142,15 @@ func (d *DidDocumentServices) GetDidDocument(ctx context.Context, did string, op
 		if identityState.GistInfo != nil {
 			gistInfoRoot = identityState.GistInfo.Root.String()
 		}
-
-		eip712TypedData, err := resolver.TypedData(*userDID, stateInfoState, gistInfoRoot, walletAddress)
+		verifyingContractChainId := 0
+		if opts.VerifyingContractChainId == nil {
+			return nil, errors.New("error verifying contract chainId is not set")
+		}
+		verifyingContractChainId = *opts.VerifyingContractChainId
+		if opts.VerifyingContractAddress == "" {
+			return nil, errors.New("error verifying contract address is not set")
+		}
+		eip712TypedData, err := resolver.TypedData(verifyingContractChainId, opts.VerifyingContractAddress, *userDID, stateInfoState, gistInfoRoot, walletAddress)
 		if err != nil {
 			return nil, fmt.Errorf("invalid typed data: %v", err)
 		}

--- a/pkg/services/did.go
+++ b/pkg/services/did.go
@@ -160,6 +160,8 @@ func (d *DidDocumentServices) GetDidDocument(ctx context.Context, did string, op
 			Created:            time.Now(),
 		}
 
+		didResolution.DidResolutionMetadata.Context = document.DidResolutionMetadataSigContext()
+		didResolution.DidResolutionMetadata.Type = document.Iden3ResolutionMetadataType
 		didResolution.DidResolutionMetadata.Proof = append(didResolution.DidResolutionMetadata.Proof, eip712Proof)
 	}
 

--- a/pkg/services/did.go
+++ b/pkg/services/did.go
@@ -142,13 +142,7 @@ func (d *DidDocumentServices) GetDidDocument(ctx context.Context, did string, op
 
 	walletAddress, err := resolver.WalletAddress()
 
-	if err == nil {
-		if opts.VerifyingContractChainId == nil {
-			return nil, errors.New("error verifying contract chainId is not set")
-		}
-		if opts.VerifyingContractAddress == "" {
-			return nil, errors.New("error verifying contract address is not set")
-		}
+	if err == nil && opts.VerifyingContractChainId != nil && opts.VerifyingContractAddress != "" {
 		verifyingContract := VerifyingContract{
 			ChainId: *opts.VerifyingContractChainId,
 			Address: opts.VerifyingContractAddress,

--- a/pkg/services/registry.go
+++ b/pkg/services/registry.go
@@ -35,11 +35,6 @@ type StateInfo struct {
 	ReplacedAtBlock     *big.Int
 }
 
-type VerifyingContract struct {
-	ChainId int
-	Address string
-}
-
 func (si *StateInfo) ToDidRepresentation() (*verifiable.StateInfo, error) {
 	if si == nil {
 		return nil, nil
@@ -103,7 +98,7 @@ type Resolver interface {
 	ResolveGist(ctx context.Context, opts *ResolverOpts) (*GistInfo, error)
 	BlockchainID() string
 	WalletAddress() (string, error)
-	TypedData(verifyingContract VerifyingContract, did w3c.DID, identityState IdentityState, walletAddress string) (apitypes.TypedData, error)
+	TypedData(did w3c.DID, identityState IdentityState, walletAddress string) (apitypes.TypedData, error)
 }
 
 type ResolverRegistry map[string]Resolver

--- a/pkg/services/registry.go
+++ b/pkg/services/registry.go
@@ -98,7 +98,7 @@ type Resolver interface {
 	ResolveGist(ctx context.Context, opts *ResolverOpts) (*GistInfo, error)
 	BlockchainID() string
 	WalletAddress() (string, error)
-	TypedData(did w3c.DID, state string, gistRoot string, walletAddress string) (apitypes.TypedData, error)
+	TypedData(verifyingContractChainId int, verifyingContractAddress string, did w3c.DID, state string, gistRoot string, walletAddress string) (apitypes.TypedData, error)
 }
 
 type ResolverRegistry map[string]Resolver

--- a/pkg/services/registry.go
+++ b/pkg/services/registry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 	"github.com/iden3/go-iden3-core/v2/w3c"
 	"github.com/iden3/go-merkletree-sql/v2"
 	"github.com/iden3/go-schema-processor/v2/verifiable"
@@ -96,6 +97,8 @@ type Resolver interface {
 	Resolve(ctx context.Context, did w3c.DID, opts *ResolverOpts) (IdentityState, error)
 	ResolveGist(ctx context.Context, opts *ResolverOpts) (*GistInfo, error)
 	BlockchainID() string
+	WalletAddress() (string, error)
+	TypedData(did w3c.DID, state string, gistRoot string, walletAddress string) (apitypes.TypedData, error)
 }
 
 type ResolverRegistry map[string]Resolver

--- a/pkg/services/registry.go
+++ b/pkg/services/registry.go
@@ -35,6 +35,11 @@ type StateInfo struct {
 	ReplacedAtBlock     *big.Int
 }
 
+type VerifyingContract struct {
+	ChainId int
+	Address string
+}
+
 func (si *StateInfo) ToDidRepresentation() (*verifiable.StateInfo, error) {
 	if si == nil {
 		return nil, nil
@@ -98,7 +103,7 @@ type Resolver interface {
 	ResolveGist(ctx context.Context, opts *ResolverOpts) (*GistInfo, error)
 	BlockchainID() string
 	WalletAddress() (string, error)
-	TypedData(verifyingContractChainId int, verifyingContractAddress string, did w3c.DID, state string, gistRoot string, walletAddress string) (apitypes.TypedData, error)
+	TypedData(verifyingContract VerifyingContract, did w3c.DID, identityState IdentityState, walletAddress string) (apitypes.TypedData, error)
 }
 
 type ResolverRegistry map[string]Resolver

--- a/pkg/services/registry.go
+++ b/pkg/services/registry.go
@@ -19,6 +19,13 @@ var (
 	ErrNotFound = errors.New("not found")
 )
 
+type PrimaryType int32
+
+const (
+	IDENTITY_STATE_TYPE PrimaryType = 0
+	GLOBAL_STATE_TYPE   PrimaryType = 1
+)
+
 type IdentityState struct {
 	StateInfo *StateInfo
 	GistInfo  *GistInfo
@@ -98,7 +105,7 @@ type Resolver interface {
 	ResolveGist(ctx context.Context, opts *ResolverOpts) (*GistInfo, error)
 	BlockchainID() string
 	WalletAddress() (string, error)
-	TypedData(did w3c.DID, identityState IdentityState, walletAddress string) (apitypes.TypedData, error)
+	TypedData(primaryType PrimaryType, did w3c.DID, identityState IdentityState, walletAddress string) (apitypes.TypedData, error)
 }
 
 type ResolverRegistry map[string]Resolver

--- a/pkg/services/registry.go
+++ b/pkg/services/registry.go
@@ -21,6 +21,7 @@ var (
 type IdentityState struct {
 	StateInfo *StateInfo
 	GistInfo  *GistInfo
+	Signature string
 }
 
 type StateInfo struct {

--- a/pkg/services/registry.go
+++ b/pkg/services/registry.go
@@ -22,8 +22,8 @@ var (
 type PrimaryType int32
 
 const (
-	IDENTITY_STATE_TYPE PrimaryType = 0
-	GLOBAL_STATE_TYPE   PrimaryType = 1
+	IdentityStateType PrimaryType = 0
+	GlobalStateType   PrimaryType = 1
 )
 
 type IdentityState struct {


### PR DESCRIPTION
## Objective
Resolver now gets all necessary state info about identity and GIST when resolving identities.
We will use the resolver as data oracle solution signing information about state of the identity and GIST.

After some research our first approach is adding a proof as EIP-712 signature in the `didResolutionMetadata` information. 
- https://github.com/decentralized-identity/did-resolver/issues/74
- https://w3c-ccg.github.io/ethereum-eip712-signature-2021-spec/

## Solution
- Add `walletKey` parameter in `resolvers.settings.yaml` with the private key of the resolver for signing in this chain
- Update `/1.0/identifiers/` to return signature based on EIP712 with the defined domain and message:
- Added new type `Iden3ResolutionMetadata` for including `retrieve` and `proof` objects in `didResolutionMetadata`
- Added contexts for new type `Iden3ResolutionMetadata` and EIP712 signature:
    - https://schema.iden3.io/core/jsonld/resolution.jsonld
    - https://w3id.org/security/suites/eip712sig-2021/v1
- 2 diferent signed messages depending on state information (issuer) or gist information (user).

IdentityState message when resolving state information (issuer):
```
"EIP712Domain": [
      { "name": "name", "type": "string" },
      { "name": "version", "type": "string" },
      { "name": "chainId", "type": "uint256" },
      { "name": "verifyingContract", "type": "address" }
    ]

 "IdentityState": [
	{ "name": "from", "type": "address" },
	{ "name": "timestamp", "type": "uint256" },
	{ "name": "identity", "type": "uint256" }
	{ "name": "state", "type": "uint256" },
	{ "name": "replacedByState", "type": "uint256" },
	{ "name": "createdAtTimestamp", "type": "uint256" },
	{ "name": "replacedAtTimestamp", "type": "uint256" },
      ]
```

GlobalState message when resolving gist information (user) passing 000000000000000000000000000000000000000000 to did:
```
"EIP712Domain": [
      { "name": "name", "type": "string" },
      { "name": "version", "type": "string" },
      { "name": "chainId", "type": "uint256" },
      { "name": "verifyingContract", "type": "address" }
    ]

 "IdentityState": [
	{ "name": "from", "type": "address" },
	{ "name": "timestamp", "type": "uint256" },
	{ "name": "root", "type": "uint256" },
	{ "name": "replacedByRoot", "type": "uint256" },
	{ "name": "createdAtTimestamp", "type": "uint256" },
	{ "name": "replacedAtTimestamp", "type": "uint256" },
      ]
```

- Create corresponding tests for checking generation and verification of the EIP712 signature and result from `/1.0/identifiers/` with signature
    - Updated `resolver_test_go`
    - Added `proof_test.go`



## Example of did document resolution:

Request:

- identitiy: `did:polygonid:polygon:amoy:2qY71pSkdCsRetTHbUA4YqG7Hx63Ej2PeiJMzAdJ2V`
- signature: `EthereumEip712Signature2021`

```
curl http://localhost:8080/1.0/identifiers/did:polygonid:polygon:amoy:2qY71pSkdCsRetTHbUA4YqG7Hx63Ej2PeiJMzAdJ2V\?signature\=EthereumEip712Signature2021
```

Response:
```
{
  "@context": "https://w3id.org/did-resolution/v1",
  "didDocument": {
    "@context": [
      "https://www.w3.org/ns/did/v1",
      "https://schema.iden3.io/core/jsonld/auth.jsonld"
    ],
    "id": "did:polygonid:polygon:amoy:2qY71pSkdCsRetTHbUA4YqG7Hx63Ej2PeiJMzAdJ2V",
    "verificationMethod": [
      {
        "id": "did:polygonid:polygon:amoy:2qY71pSkdCsRetTHbUA4YqG7Hx63Ej2PeiJMzAdJ2V#stateInfo",
        "type": "Iden3StateInfo2023",
        "controller": "did:polygonid:polygon:amoy:2qY71pSkdCsRetTHbUA4YqG7Hx63Ej2PeiJMzAdJ2V",
        "stateContractAddress": "80002:0x1a4cC30f2aA0377b0c3bc9848766D90cb4404124",
        "published": true,
        "info": {
          "id": "did:polygonid:polygon:amoy:2qY71pSkdCsRetTHbUA4YqG7Hx63Ej2PeiJMzAdJ2V",
          "state": "9a73b7f0f5f0a9b5e2dab8bdcecf4fa003ef531c1c61307c79483d51f5474c1e",
          "replacedByState": "0000000000000000000000000000000000000000000000000000000000000000",
          "createdAtTimestamp": "1720111993",
          "replacedAtTimestamp": "0",
          "createdAtBlock": "9068720",
          "replacedAtBlock": "0"
        },
        "global": {
          "root": "06a733d69bfc34e9d30fcbc5077b0c38bad6864c19ceadf7be5b5000c63eef28",
          "replacedByRoot": "0000000000000000000000000000000000000000000000000000000000000000",
          "createdAtTimestamp": "1721908926",
          "replacedAtTimestamp": "0",
          "createdAtBlock": "9913272",
          "replacedAtBlock": "0"
        }
      }
    ]
  },
  "didResolutionMetadata": {
    "@context": [
      "https://schema.iden3.io/core/jsonld/resolution.jsonld",
      "https://w3id.org/security/suites/eip712sig-2021/v1"
    ],
    "contentType": "application/did+ld+json",
    "retrieved": "2024-07-25T14:32:46.925776953Z",
    "type": "Iden3ResolutionMetadata",
    "proof": [
      {
        "type": "EthereumEip712Signature2021",
        "proofPurpose": "assertionMethod",
        "proofValue": "0x3605ffb2acdfe4ce66778da36abb0dc88634a76131dd2b59c18e9c1259c8cca34a2169acdcb60507014a59959bf9dee3d2291b10318f8d062531fa468ae29e011b",
        "verificationMethod": "did:pkh:eip155:0:0x615031554479128d65f30Ffa721791D6441d9727#blockchainAccountId",
        "created": "2024-07-25T14:32:46.925846416Z",
        "eip712": {
          "types": {
            "EIP712Domain": [
              { "name": "name", "type": "string" },
              { "name": "version", "type": "string" },
              { "name": "chainId", "type": "uint256" },
              { "name": "verifyingContract", "type": "address" }
            ],
            "IdentityState": [
              { "name": "from", "type": "address" },
              { "name": "timestamp", "type": "uint256" },
              { "name": "identity", "type": "uint256" },
              { "name": "state", "type": "uint256" },
              { "name": "replacedByState", "type": "uint256" },
              { "name": "createdAtTimestamp", "type": "uint256" },
              { "name": "replacedAtTimestamp", "type": "uint256" }
            ]
          },
          "primaryType": "IdentityState",
          "domain": {
            "name": "StateInfo",
            "version": "1",
            "chainId": "0x0",
            "verifyingContract": "0x0000000000000000000000000000000000000000"
          },
          "message": {
            "createdAtTimestamp": "1721908926",
            "from": "0x615031554479128d65f30Ffa721791D6441d9727",
            "identity": "19090607534999372304474213543962416547920895595808567155882840509226423042",
            "replacedAtTimestamp": "0",
            "replacedByState": "0",
            "state": "13704162472154210473949595093402377697496480870900777124562670166655890846618",
            "timestamp": "1721917966"
          }
        }
      }
    ]
  },
  "didDocumentMetadata": {}
}
```

## Test
- Updated `resolver_test_go`
- Added `proof_test.go`

You can execute tests with
```
make test
```